### PR TITLE
Add backend and frontend security CI checks

### DIFF
--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: security-ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   backend-security:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches-ignore: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: security-ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -1,0 +1,70 @@
+name: Security CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches-ignore: [main]
+
+concurrency:
+  group: security-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-security:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run Bandit security scan
+        run: |
+          bandit -r app mcp_servers main.py llm.py \
+            -x tests,vendor \
+            --skip B104 \
+            --severity-level medium \
+            --confidence-level medium
+
+  frontend-security:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --audit-level=high

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Thank you for contributing to STRATOS. This document covers the branch strategy,
 
 ## CI Checks
 
-CI runs automatically on every pull request targeting `main` and on every push to non-main branches. Two workflows run in parallel:
+CI runs automatically on every pull request targeting `main` and on every push to non-main branches. Three workflows run in parallel:
 
 ### Frontend CI (`frontend-ci.yml`)
 
@@ -68,7 +68,16 @@ CI runs automatically on every pull request targeting `main` and on every push t
 | Import validation | `python -c "import main"` | The app cannot be imported (broken imports, syntax errors) |
 | Tests | `pytest` | Any test fails (runs only if a `tests/` directory exists) |
 
-A PR **cannot be merged** if either CI job is failing.
+### Security CI (`security-ci.yml`)
+
+| Step | Command | Fails if... |
+|------|---------|-------------|
+| Backend security scan | `bandit -r app mcp_servers main.py llm.py -x tests,vendor --skip B104 --severity-level medium --confidence-level medium` | Bandit finds a medium-or-higher confidence security issue in STRATOS backend code |
+| Frontend dependency audit | `npm audit --audit-level=high` | npm reports a high-or-critical advisory for installed frontend dependencies |
+
+Security checks intentionally scan STRATOS-owned backend code and exclude `backend/vendor/` so vendored HAB predictor code does not drown out actionable findings. Bandit `B104` is skipped because the API bind host is deployment-configurable and currently defaults to `0.0.0.0`. Add new suppressions only when a finding is reviewed and intentional.
+
+A PR **cannot be merged** if any CI job is failing.
 
 ---
 
@@ -78,7 +87,7 @@ A PR **cannot be merged** if either CI job is failing.
 - At least 1 approving review required
 - Stale approvals dismissed when new commits are pushed
 - All conversations must be resolved before merge
-- Status checks (`Frontend CI` and `Backend CI`) must pass before merge
+- Status checks (`Frontend CI`, `Backend CI`, and `Security CI`) must pass before merge
 - Direct pushes to `main` are blocked
 
 ---
@@ -103,9 +112,26 @@ pip install -r requirements.txt -r requirements-dev.txt
 uvicorn main:app --reload   # Dev server at http://localhost:8000
 ruff check .                # Lint
 pytest                      # Run tests (when tests exist)
+bandit -r app mcp_servers main.py llm.py -x tests,vendor --skip B104 --severity-level medium --confidence-level medium
 ```
 
 Copy `.env.example` to `.env` and fill in your local values before running the backend.
+
+### Security checks
+
+Run the same security checks as CI before opening a PR:
+
+```bash
+cd backend
+pip install -r requirements.txt -r requirements-dev.txt
+bandit -r app mcp_servers main.py llm.py -x tests,vendor --skip B104 --severity-level medium --confidence-level medium
+```
+
+```bash
+cd frontend
+npm ci
+npm audit --audit-level=high
+```
 
 ---
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 ruff
+bandit


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One or two sentences. -->
Adds automated security checks to CI so STRATOS can catch basic backend and frontend security regressions before merge.

Closes #<!-- issue number -->

## Changes

<!-- Brief list of what changed and why. -->
- Added a new `Security CI` GitHub Actions workflow.
- Added a backend security job that runs Bandit against STRATOS-owned Python backend code.
- Added a frontend security job that runs `npm audit --audit-level=high`.
- Added `bandit` to `backend/requirements-dev.txt`.
- Documented the new CI checks and local security commands in `CONTRIBUTING.md`.
- Documented the intentional Bandit `B104` skip for the deployment-configurable `0.0.0.0` bind default.

-

## Testing

<!-- How did you verify this works? -->

- [ ] Frontend CI passes (lint + build)
- [ ] Backend CI passes (lint + import check + tests)
- [ x] Tested locally

Local checks run:

- [x] `ruff check .`
- [x] `bandit -r app mcp_servers main.py llm.py -x tests,vendor --skip B104 --severity-level medium --confidence-level medium`
- [x] GitHub Actions workflow YAML parsed successfully
- [x] `npm audit --audit-level=high`

## Notes for reviewer

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
`backend/vendor/` is excluded from Bandit so vendored HAB predictor code does not create noisy findings unrelated to STRATOS-owned changes. `npm audit` fails only on high/critical advisories to keep CI actionable while avoiding current moderate dependency noise.