### PR TITLE
[BACKEND][MISSION] Add mission-aware runtime request contract

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/CHANGELOG.md
+++ b/.agents/skills/supabase-postgres-best-practices/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## [1.3.0](https://github.com/supabase/agent-skills/compare/v1.2.0...v1.3.0) (2026-06-05)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+
+## [1.2.0](https://github.com/supabase/agent-skills/compare/v1.1.1...v1.2.0) (2026-06-02)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))

--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: supabase-postgres-best-practices
+description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+license: MIT
+metadata:
+  author: supabase
+  version: "1.1.1"
+  organization: Supabase
+  date: January 2026
+  abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+---
+
+# Supabase Postgres Best Practices
+
+Comprehensive performance optimization guide for Postgres, maintained by Supabase. Contains rules across 8 categories, prioritized by impact to guide automated query optimization and schema design.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing SQL queries or designing schemas
+- Implementing indexes or query optimization
+- Reviewing database performance issues
+- Configuring connection pooling or scaling
+- Optimizing for Postgres-specific features
+- Working with Row-Level Security (RLS)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Query Performance | CRITICAL | `query-` |
+| 2 | Connection Management | CRITICAL | `conn-` |
+| 3 | Security & RLS | CRITICAL | `security-` |
+| 4 | Schema Design | HIGH | `schema-` |
+| 5 | Concurrency & Locking | MEDIUM-HIGH | `lock-` |
+| 6 | Data Access Patterns | MEDIUM | `data-` |
+| 7 | Monitoring & Diagnostics | LOW-MEDIUM | `monitor-` |
+| 8 | Advanced Features | LOW | `advanced-` |
+
+## How to Use
+
+Read individual rule files for detailed explanations and SQL examples:
+
+```
+references/query-missing-indexes.md
+references/query-partial-indexes.md
+references/_sections.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect SQL example with explanation
+- Correct SQL example with explanation
+- Optional EXPLAIN output or metrics
+- Additional context and references
+- Supabase-specific notes (when applicable)
+
+## References
+
+- https://www.postgresql.org/docs/current/
+- https://supabase.com/docs
+- https://wiki.postgresql.org/wiki/Performance_Optimization
+- https://supabase.com/docs/guides/database/overview
+- https://supabase.com/docs/guides/auth/row-level-security

--- a/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -1,0 +1,170 @@
+# Writing Guidelines for Postgres References
+
+This document provides guidelines for creating effective Postgres best
+practice references that work well with AI agents and LLMs.
+
+## Key Principles
+
+### 1. Concrete Transformation Patterns
+
+Show exact SQL rewrites. Avoid philosophical advice.
+
+**Good:** "Use `WHERE id = ANY(ARRAY[...])` instead of
+`WHERE id IN (SELECT ...)`" **Bad:** "Design good schemas"
+
+### 2. Error-First Structure
+
+Always show the problematic pattern first, then the solution. This trains agents
+to recognize anti-patterns.
+
+```markdown
+**Incorrect (sequential queries):** [bad example]
+
+**Correct (batched query):** [good example]
+```
+
+### 3. Quantified Impact
+
+Include specific metrics. Helps agents prioritize fixes.
+
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Bad:** "Faster", "Better", "More efficient"
+
+### 4. Self-Contained Examples
+
+Examples should be complete and runnable (or close to it). Include `CREATE TABLE`
+if context is needed.
+
+```sql
+-- Include table definition when needed for clarity
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  deleted_at timestamptz
+);
+
+-- Now show the index
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+```
+
+### 5. Semantic Naming
+
+Use meaningful table/column names. Names carry intent for LLMs.
+
+**Good:** `users`, `email`, `created_at`, `is_active`
+**Bad:** `table1`, `col1`, `field`, `flag`
+
+---
+
+## Code Example Standards
+
+### SQL Formatting
+
+```sql
+-- Use lowercase keywords, clear formatting
+CREATE INDEX CONCURRENTLY users_email_idx
+  ON users(email)
+  WHERE deleted_at IS NULL;
+
+-- Not cramped or ALL CAPS
+CREATE INDEX CONCURRENTLY USERS_EMAIL_IDX ON USERS(EMAIL) WHERE DELETED_AT IS NULL;
+```
+
+### Comments
+
+- Explain _why_, not _what_
+- Highlight performance implications
+- Point out common pitfalls
+
+### Language Tags
+
+- `sql` - Standard SQL queries
+- `plpgsql` - Stored procedures/functions
+- `typescript` - Application code (when needed)
+- `python` - Application code (when needed)
+
+---
+
+## When to Include Application Code
+
+**Default: SQL Only**
+
+Most references should focus on pure SQL patterns. This keeps examples portable.
+
+**Include Application Code When:**
+
+- Connection pooling configuration
+- Transaction management in application context
+- ORM anti-patterns (N+1 in Prisma/TypeORM)
+- Prepared statement usage
+
+**Format for Mixed Examples:**
+
+````markdown
+**Incorrect (N+1 in application):**
+
+```typescript
+for (const user of users) {
+  const posts = await db.query("SELECT * FROM posts WHERE user_id = $1", [
+    user.id,
+  ]);
+}
+```
+````
+
+**Correct (batch query):**
+
+```typescript
+const posts = await db.query("SELECT * FROM posts WHERE user_id = ANY($1)", [
+  userIds,
+]);
+```
+
+---
+
+## Impact Level Guidelines
+
+| Level | Improvement | Use When |
+|-------|-------------|----------|
+| **CRITICAL** | 10-100x | Missing indexes, connection exhaustion, sequential scans on large tables |
+| **HIGH** | 5-20x | Wrong index types, poor partitioning, missing covering indexes |
+| **MEDIUM-HIGH** | 2-5x | N+1 queries, inefficient pagination, RLS optimization |
+| **MEDIUM** | 1.5-3x | Redundant indexes, query plan instability |
+| **LOW-MEDIUM** | 1.2-2x | VACUUM tuning, configuration tweaks |
+| **LOW** | Incremental | Advanced patterns, edge cases |
+
+---
+
+## Reference Standards
+
+**Primary Sources:**
+
+- Official Postgres documentation
+- Supabase documentation
+- Postgres wiki
+- Established blogs (2ndQuadrant, Crunchy Data)
+
+**Format:**
+
+```markdown
+Reference:
+[Postgres Indexes](https://www.postgresql.org/docs/current/indexes.html)
+```
+
+---
+
+## Review Checklist
+
+Before submitting a reference:
+
+- [ ] Title is clear and action-oriented
+- [ ] Impact level matches the performance gain
+- [ ] impactDescription includes quantification
+- [ ] Explanation is concise (1-2 sentences)
+- [ ] Has at least 1 **Incorrect** SQL example
+- [ ] Has at least 1 **Correct** SQL example
+- [ ] SQL uses semantic naming
+- [ ] Comments explain _why_, not _what_
+- [ ] Trade-offs mentioned if applicable
+- [ ] Reference links included
+- [ ] `pnpm test` passes

--- a/.agents/skills/supabase-postgres-best-practices/references/_sections.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_sections.md
@@ -1,0 +1,39 @@
+# Section Definitions
+
+This file defines the rule categories for Postgres best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+Take the examples below as pure demonstrative. Replace each section with the actual rule categories for Postgres best practices.
+
+---
+
+## 1. Query Performance (query)
+**Impact:** CRITICAL
+**Description:** Slow queries, missing indexes, inefficient query plans. The most common source of Postgres performance issues.
+
+## 2. Connection Management (conn)
+**Impact:** CRITICAL
+**Description:** Connection pooling, limits, and serverless strategies. Critical for applications with high concurrency or serverless deployments.
+
+## 3. Security & RLS (security)
+**Impact:** CRITICAL
+**Description:** Row-Level Security policies, privilege management, and authentication patterns.
+
+## 4. Schema Design (schema)
+**Impact:** HIGH
+**Description:** Table design, index strategies, partitioning, and data type selection. Foundation for long-term performance.
+
+## 5. Concurrency & Locking (lock)
+**Impact:** MEDIUM-HIGH
+**Description:** Transaction management, isolation levels, deadlock prevention, and lock contention patterns.
+
+## 6. Data Access Patterns (data)
+**Impact:** MEDIUM
+**Description:** N+1 query elimination, batch operations, cursor-based pagination, and efficient data fetching.
+
+## 7. Monitoring & Diagnostics (monitor)
+**Impact:** LOW-MEDIUM
+**Description:** Using pg_stat_statements, EXPLAIN ANALYZE, metrics collection, and performance diagnostics.
+
+## 8. Advanced Features (advanced)
+**Impact:** LOW
+**Description:** Full-text search, JSONB optimization, PostGIS, extensions, and advanced Postgres features.

--- a/.agents/skills/supabase-postgres-best-practices/references/_template.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_template.md
@@ -1,0 +1,34 @@
+---
+title: Clear, Action-Oriented Title (e.g., "Use Partial Indexes for Filtered Queries")
+impact: MEDIUM
+impactDescription: 5-20x query speedup for filtered queries
+tags: indexes, query-optimization, performance
+---
+
+## [Rule Title]
+
+[1-2 sentence explanation of the problem and why it matters. Focus on performance impact.]
+
+**Incorrect (describe the problem):**
+
+```sql
+-- Comment explaining what makes this slow/problematic
+CREATE INDEX users_email_idx ON users(email);
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- This scans deleted records unnecessarily
+```
+
+**Correct (describe the solution):**
+
+```sql
+-- Comment explaining why this is better
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- Only indexes active users, 10x smaller index, faster queries
+```
+
+[Optional: Additional context, edge cases, or trade-offs]
+
+Reference: [Postgres Docs](https://www.postgresql.org/docs/current/)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
@@ -1,0 +1,55 @@
+---
+title: Use tsvector for Full-Text Search
+impact: MEDIUM
+impactDescription: 100x faster than LIKE, with ranking support
+tags: full-text-search, tsvector, gin, search
+---
+
+## Use tsvector for Full-Text Search
+
+LIKE with wildcards can't use indexes. Full-text search with tsvector is orders of magnitude faster.
+
+**Incorrect (LIKE pattern matching):**
+
+```sql
+-- Cannot use index, scans all rows
+select * from articles where content like '%postgresql%';
+
+-- Case-insensitive makes it worse
+select * from articles where lower(content) like '%postgresql%';
+```
+
+**Correct (full-text search with tsvector):**
+
+```sql
+-- Add tsvector column and index
+alter table articles add column search_vector tsvector
+  generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,''))) stored;
+
+create index articles_search_idx on articles using gin (search_vector);
+
+-- Fast full-text search
+select * from articles
+where search_vector @@ to_tsquery('english', 'postgresql & performance');
+
+-- With ranking
+select *, ts_rank(search_vector, query) as rank
+from articles, to_tsquery('english', 'postgresql') query
+where search_vector @@ query
+order by rank desc;
+```
+
+Search multiple terms:
+
+```sql
+-- AND: both terms required
+to_tsquery('postgresql & performance')
+
+-- OR: either term
+to_tsquery('postgresql | mysql')
+
+-- Prefix matching
+to_tsquery('post:*')
+```
+
+Reference: [Full Text Search](https://supabase.com/docs/guides/database/full-text-search)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
@@ -1,0 +1,49 @@
+---
+title: Index JSONB Columns for Efficient Querying
+impact: MEDIUM
+impactDescription: 10-100x faster JSONB queries with proper indexing
+tags: jsonb, gin, indexes, json
+---
+
+## Index JSONB Columns for Efficient Querying
+
+JSONB queries without indexes scan the entire table. Use GIN indexes for containment queries.
+
+**Incorrect (no index on JSONB):**
+
+```sql
+create table products (
+  id bigint primary key,
+  attributes jsonb
+);
+
+-- Full table scan for every query
+select * from products where attributes @> '{"color": "red"}';
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+**Correct (GIN index for JSONB):**
+
+```sql
+-- GIN index for containment operators (@>, ?, ?&, ?|)
+create index products_attrs_gin on products using gin (attributes);
+
+-- Now containment queries use the index
+select * from products where attributes @> '{"color": "red"}';
+
+-- For specific key lookups, use expression index
+create index products_brand_idx on products ((attributes->>'brand'));
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+Choose the right operator class:
+
+```sql
+-- jsonb_ops (default): supports all operators, larger index
+create index idx1 on products using gin (attributes);
+
+-- jsonb_path_ops: only @> operator, but 2-3x smaller index
+create index idx2 on products using gin (attributes jsonb_path_ops);
+```
+
+Reference: [JSONB Indexes](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
@@ -1,0 +1,46 @@
+---
+title: Configure Idle Connection Timeouts
+impact: HIGH
+impactDescription: Reclaim 30-50% of connection slots from idle clients
+tags: connections, timeout, idle, resource-management
+---
+
+## Configure Idle Connection Timeouts
+
+Idle connections waste resources. Configure timeouts to automatically reclaim them.
+
+**Incorrect (connections held indefinitely):**
+
+```sql
+-- No timeout configured
+show idle_in_transaction_session_timeout;  -- 0 (disabled)
+
+-- Connections stay open forever, even when idle
+select pid, state, state_change, query
+from pg_stat_activity
+where state = 'idle in transaction';
+-- Shows transactions idle for hours, holding locks
+```
+
+**Correct (automatic cleanup of idle connections):**
+
+```sql
+-- Terminate connections idle in transaction after 30 seconds
+alter system set idle_in_transaction_session_timeout = '30s';
+
+-- Terminate completely idle connections after 10 minutes
+alter system set idle_session_timeout = '10min';
+
+-- Reload configuration
+select pg_reload_conf();
+```
+
+For pooled connections, configure at the pooler level:
+
+```ini
+# pgbouncer.ini
+server_idle_timeout = 60
+client_idle_timeout = 300
+```
+
+Reference: [Connection Timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
@@ -1,0 +1,44 @@
+---
+title: Set Appropriate Connection Limits
+impact: CRITICAL
+impactDescription: Prevent database crashes and memory exhaustion
+tags: connections, max-connections, limits, stability
+---
+
+## Set Appropriate Connection Limits
+
+Too many connections exhaust memory and degrade performance. Set limits based on available resources.
+
+**Incorrect (unlimited or excessive connections):**
+
+```sql
+-- Default max_connections = 100, but often increased blindly
+show max_connections;  -- 500 (way too high for 4GB RAM)
+
+-- Each connection uses 1-3MB RAM
+-- 500 connections * 2MB = 1GB just for connections!
+-- Out of memory errors under load
+```
+
+**Correct (calculate based on resources):**
+
+```sql
+-- Formula: max_connections = (RAM in MB / 5MB per connection) - reserved
+-- For 4GB RAM: (4096 / 5) - 10 = ~800 theoretical max
+-- But practically, 100-200 is better for query performance
+
+-- Recommended settings for 4GB RAM
+alter system set max_connections = 100;
+
+-- Also set work_mem appropriately
+-- work_mem * max_connections should not exceed 25% of RAM
+alter system set work_mem = '8MB';  -- 8MB * 100 = 800MB max
+```
+
+Monitor connection usage:
+
+```sql
+select count(*), state from pg_stat_activity group by state;
+```
+
+Reference: [Database Connections](https://supabase.com/docs/guides/platform/performance#connection-management)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
@@ -1,0 +1,41 @@
+---
+title: Use Connection Pooling for All Applications
+impact: CRITICAL
+impactDescription: Handle 10-100x more concurrent users
+tags: connection-pooling, pgbouncer, performance, scalability
+---
+
+## Use Connection Pooling for All Applications
+
+Postgres connections are expensive (1-3MB RAM each). Without pooling, applications exhaust connections under load.
+
+**Incorrect (new connection per request):**
+
+```sql
+-- Each request creates a new connection
+-- Application code: db.connect() per request
+-- Result: 500 concurrent users = 500 connections = crashed database
+
+-- Check current connections
+select count(*) from pg_stat_activity;  -- 487 connections!
+```
+
+**Correct (connection pooling):**
+
+```sql
+-- Use a pooler like PgBouncer between app and database
+-- Application connects to pooler, pooler reuses a small pool to Postgres
+
+-- Configure pool_size based on: (CPU cores * 2) + spindle_count
+-- Example for 4 cores: pool_size = 10
+
+-- Result: 500 concurrent users share 10 actual connections
+select count(*) from pg_stat_activity;  -- 10 connections
+```
+
+Pool modes:
+
+- **Transaction mode**: connection returned after each transaction (best for most apps)
+- **Session mode**: connection held for entire session (needed for prepared statements, temp tables)
+
+Reference: [Connection Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
@@ -1,0 +1,46 @@
+---
+title: Use Prepared Statements Correctly with Pooling
+impact: HIGH
+impactDescription: Avoid prepared statement conflicts in pooled environments
+tags: prepared-statements, connection-pooling, transaction-mode
+---
+
+## Use Prepared Statements Correctly with Pooling
+
+Prepared statements are tied to individual database connections. In transaction-mode pooling, connections are shared, causing conflicts.
+
+**Incorrect (named prepared statements with transaction pooling):**
+
+```sql
+-- Named prepared statement
+prepare get_user as select * from users where id = $1;
+
+-- In transaction mode pooling, next request may get different connection
+execute get_user(123);
+-- ERROR: prepared statement "get_user" does not exist
+```
+
+**Correct (use unnamed statements or session mode):**
+
+```sql
+-- Option 1: Use unnamed prepared statements (most ORMs do this automatically)
+-- The query is prepared and executed in a single protocol message
+
+-- Option 2: Deallocate after use in transaction mode
+prepare get_user as select * from users where id = $1;
+execute get_user(123);
+deallocate get_user;
+
+-- Option 3: Use session mode pooling (port 5432 vs 6543)
+-- Connection is held for entire session, prepared statements persist
+```
+
+Check your driver settings:
+
+```sql
+-- Many drivers use prepared statements by default
+-- Node.js pg: { prepare: false } to disable
+-- JDBC: prepareThreshold=0 to disable
+```
+
+Reference: [Prepared Statements with Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool-modes)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
@@ -1,0 +1,54 @@
+---
+title: Batch INSERT Statements for Bulk Data
+impact: MEDIUM
+impactDescription: 10-50x faster bulk inserts
+tags: batch, insert, bulk, performance, copy
+---
+
+## Batch INSERT Statements for Bulk Data
+
+Individual INSERT statements have high overhead. Batch multiple rows in single statements or use COPY.
+
+**Incorrect (individual inserts):**
+
+```sql
+-- Each insert is a separate transaction and round trip
+insert into events (user_id, action) values (1, 'click');
+insert into events (user_id, action) values (1, 'view');
+insert into events (user_id, action) values (2, 'click');
+-- ... 1000 more individual inserts
+
+-- 1000 inserts = 1000 round trips = slow
+```
+
+**Correct (batch insert):**
+
+```sql
+-- Multiple rows in single statement
+insert into events (user_id, action) values
+  (1, 'click'),
+  (1, 'view'),
+  (2, 'click'),
+  -- ... up to ~1000 rows per batch
+  (999, 'view');
+
+-- One round trip for 1000 rows
+```
+
+For large imports, use COPY:
+
+```sql
+-- COPY is fastest for bulk loading
+copy events (user_id, action, created_at)
+from '/path/to/data.csv'
+with (format csv, header true);
+
+-- Or from stdin in application
+copy events (user_id, action) from stdin with (format csv);
+1,click
+1,view
+2,click
+\.
+```
+
+Reference: [COPY](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
@@ -1,0 +1,53 @@
+---
+title: Eliminate N+1 Queries with Batch Loading
+impact: MEDIUM-HIGH
+impactDescription: 10-100x fewer database round trips
+tags: n-plus-one, batch, performance, queries
+---
+
+## Eliminate N+1 Queries with Batch Loading
+
+N+1 queries execute one query per item in a loop. Batch them into a single query using arrays or JOINs.
+
+**Incorrect (N+1 queries):**
+
+```sql
+-- First query: get all users
+select id from users where active = true;  -- Returns 100 IDs
+
+-- Then N queries, one per user
+select * from orders where user_id = 1;
+select * from orders where user_id = 2;
+select * from orders where user_id = 3;
+-- ... 97 more queries!
+
+-- Total: 101 round trips to database
+```
+
+**Correct (single batch query):**
+
+```sql
+-- Collect IDs and query once with ANY
+select * from orders where user_id = any(array[1, 2, 3, ...]);
+
+-- Or use JOIN instead of loop
+select u.id, u.name, o.*
+from users u
+left join orders o on o.user_id = u.id
+where u.active = true;
+
+-- Total: 1 round trip
+```
+
+Application pattern:
+
+```sql
+-- Instead of looping in application code:
+-- for user in users: db.query("SELECT * FROM orders WHERE user_id = $1", user.id)
+
+-- Pass array parameter:
+select * from orders where user_id = any($1::bigint[]);
+-- Application passes: [1, 2, 3, 4, 5, ...]
+```
+
+Reference: [N+1 Query Problem](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -1,0 +1,50 @@
+---
+title: Use Cursor-Based Pagination Instead of OFFSET
+impact: MEDIUM-HIGH
+impactDescription: Consistent O(1) performance regardless of page depth
+tags: pagination, cursor, keyset, offset, performance
+---
+
+## Use Cursor-Based Pagination Instead of OFFSET
+
+OFFSET-based pagination scans all skipped rows, getting slower on deeper pages. Cursor pagination is O(1).
+
+**Incorrect (OFFSET pagination):**
+
+```sql
+-- Page 1: scans 20 rows
+select * from products order by id limit 20 offset 0;
+
+-- Page 100: scans 2000 rows to skip 1980
+select * from products order by id limit 20 offset 1980;
+
+-- Page 10000: scans 200,000 rows!
+select * from products order by id limit 20 offset 199980;
+```
+
+**Correct (cursor/keyset pagination):**
+
+```sql
+-- Page 1: get first 20
+select * from products order by id limit 20;
+-- Application stores last_id = 20
+
+-- Page 2: start after last ID
+select * from products where id > 20 order by id limit 20;
+-- Uses index, always fast regardless of page depth
+
+-- Page 10000: same speed as page 1
+select * from products where id > 199980 order by id limit 20;
+```
+
+For multi-column sorting:
+
+```sql
+-- Cursor must include all sort columns
+select * from products
+where (created_at, id) > ('2024-01-15 10:00:00', 12345)
+order by created_at, id
+limit 20;
+```
+
+Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
@@ -1,0 +1,50 @@
+---
+title: Use UPSERT for Insert-or-Update Operations
+impact: MEDIUM
+impactDescription: Atomic operation, eliminates race conditions
+tags: upsert, on-conflict, insert, update
+---
+
+## Use UPSERT for Insert-or-Update Operations
+
+Using separate SELECT-then-INSERT/UPDATE creates race conditions. Use INSERT ... ON CONFLICT for atomic upserts.
+
+**Incorrect (check-then-insert race condition):**
+
+```sql
+-- Race condition: two requests check simultaneously
+select * from settings where user_id = 123 and key = 'theme';
+-- Both find nothing
+
+-- Both try to insert
+insert into settings (user_id, key, value) values (123, 'theme', 'dark');
+-- One succeeds, one fails with duplicate key error!
+```
+
+**Correct (atomic UPSERT):**
+
+```sql
+-- Single atomic operation
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value, updated_at = now();
+
+-- Returns the inserted/updated row
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value
+returning *;
+```
+
+Insert-or-ignore pattern:
+
+```sql
+-- Insert only if not exists (no update)
+insert into page_views (page_id, user_id)
+values (1, 123)
+on conflict (page_id, user_id) do nothing;
+```
+
+Reference: [INSERT ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
@@ -1,0 +1,56 @@
+---
+title: Use Advisory Locks for Application-Level Locking
+impact: MEDIUM
+impactDescription: Efficient coordination without row-level lock overhead
+tags: advisory-locks, coordination, application-locks
+---
+
+## Use Advisory Locks for Application-Level Locking
+
+Advisory locks provide application-level coordination without requiring database rows to lock.
+
+**Incorrect (creating rows just for locking):**
+
+```sql
+-- Creating dummy rows to lock on
+create table resource_locks (
+  resource_name text primary key
+);
+
+insert into resource_locks values ('report_generator');
+
+-- Lock by selecting the row
+select * from resource_locks where resource_name = 'report_generator' for update;
+```
+
+**Correct (advisory locks):**
+
+```sql
+-- Session-level advisory lock (released on disconnect or unlock)
+select pg_advisory_lock(hashtext('report_generator'));
+-- ... do exclusive work ...
+select pg_advisory_unlock(hashtext('report_generator'));
+
+-- Transaction-level lock (released on commit/rollback)
+begin;
+select pg_advisory_xact_lock(hashtext('daily_report'));
+-- ... do work ...
+commit;  -- Lock automatically released
+```
+
+Try-lock for non-blocking operations:
+
+```sql
+-- Returns immediately with true/false instead of waiting
+select pg_try_advisory_lock(hashtext('resource_name'));
+
+-- Use in application
+if (acquired) {
+  -- Do work
+  select pg_advisory_unlock(hashtext('resource_name'));
+} else {
+  -- Skip or retry later
+}
+```
+
+Reference: [Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
@@ -1,0 +1,68 @@
+---
+title: Prevent Deadlocks with Consistent Lock Ordering
+impact: MEDIUM-HIGH
+impactDescription: Eliminate deadlock errors, improve reliability
+tags: deadlocks, locking, transactions, ordering
+---
+
+## Prevent Deadlocks with Consistent Lock Ordering
+
+Deadlocks occur when transactions lock resources in different orders. Always
+acquire locks in a consistent order.
+
+**Incorrect (inconsistent lock ordering):**
+
+```sql
+-- Transaction A                    -- Transaction B
+begin;                              begin;
+update accounts                     update accounts
+set balance = balance - 100         set balance = balance - 50
+where id = 1;                       where id = 2;  -- B locks row 2
+
+update accounts                     update accounts
+set balance = balance + 100         set balance = balance + 50
+where id = 2;  -- A waits for B     where id = 1;  -- B waits for A
+
+-- DEADLOCK! Both waiting for each other
+```
+
+**Correct (lock rows in consistent order first):**
+
+```sql
+-- Explicitly acquire locks in ID order before updating
+begin;
+select * from accounts where id in (1, 2) order by id for update;
+
+-- Now perform updates in any order - locks already held
+update accounts set balance = balance - 100 where id = 1;
+update accounts set balance = balance + 100 where id = 2;
+commit;
+```
+
+Alternative: use a single statement to update atomically:
+
+```sql
+-- Single statement acquires all locks atomically
+begin;
+update accounts
+set balance = balance + case id
+  when 1 then -100
+  when 2 then 100
+end
+where id in (1, 2);
+commit;
+```
+
+Detect deadlocks in logs:
+
+```sql
+-- Check for recent deadlocks
+select * from pg_stat_database where deadlocks > 0;
+
+-- Enable deadlock logging
+set log_lock_waits = on;
+set deadlock_timeout = '1s';
+```
+
+Reference:
+[Deadlocks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
@@ -1,0 +1,50 @@
+---
+title: Keep Transactions Short to Reduce Lock Contention
+impact: MEDIUM-HIGH
+impactDescription: 3-5x throughput improvement, fewer deadlocks
+tags: transactions, locking, contention, performance
+---
+
+## Keep Transactions Short to Reduce Lock Contention
+
+Long-running transactions hold locks that block other queries. Keep transactions as short as possible.
+
+**Incorrect (long transaction with external calls):**
+
+```sql
+begin;
+select * from orders where id = 1 for update;  -- Lock acquired
+
+-- Application makes HTTP call to payment API (2-5 seconds)
+-- Other queries on this row are blocked!
+
+update orders set status = 'paid' where id = 1;
+commit;  -- Lock held for entire duration
+```
+
+**Correct (minimal transaction scope):**
+
+```sql
+-- Validate data and call APIs outside transaction
+-- Application: response = await paymentAPI.charge(...)
+
+-- Only hold lock for the actual update
+begin;
+update orders
+set status = 'paid', payment_id = $1
+where id = $2 and status = 'pending'
+returning *;
+commit;  -- Lock held for milliseconds
+```
+
+Use `statement_timeout` to prevent runaway transactions:
+
+```sql
+-- Abort queries running longer than 30 seconds
+set statement_timeout = '30s';
+
+-- Or per-session
+set local statement_timeout = '5s';
+```
+
+Reference: [Transaction Management](https://www.postgresql.org/docs/current/tutorial-transactions.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
@@ -1,0 +1,54 @@
+---
+title: Use SKIP LOCKED for Non-Blocking Queue Processing
+impact: MEDIUM-HIGH
+impactDescription: 10x throughput for worker queues
+tags: skip-locked, queue, workers, concurrency
+---
+
+## Use SKIP LOCKED for Non-Blocking Queue Processing
+
+When multiple workers process a queue, SKIP LOCKED allows workers to process different rows without waiting.
+
+**Incorrect (workers block each other):**
+
+```sql
+-- Worker 1 and Worker 2 both try to get next job
+begin;
+select * from jobs where status = 'pending' order by created_at limit 1 for update;
+-- Worker 2 waits for Worker 1's lock to release!
+```
+
+**Correct (SKIP LOCKED for parallel processing):**
+
+```sql
+-- Each worker skips locked rows and gets the next available
+begin;
+select * from jobs
+where status = 'pending'
+order by created_at
+limit 1
+for update skip locked;
+
+-- Worker 1 gets job 1, Worker 2 gets job 2 (no waiting)
+
+update jobs set status = 'processing' where id = $1;
+commit;
+```
+
+Complete queue pattern:
+
+```sql
+-- Atomic claim-and-update in one statement
+update jobs
+set status = 'processing', worker_id = $1, started_at = now()
+where id = (
+  select id from jobs
+  where status = 'pending'
+  order by created_at
+  limit 1
+  for update skip locked
+)
+returning *;
+```
+
+Reference: [SELECT FOR UPDATE SKIP LOCKED](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
@@ -1,0 +1,45 @@
+---
+title: Use EXPLAIN ANALYZE to Diagnose Slow Queries
+impact: LOW-MEDIUM
+impactDescription: Identify exact bottlenecks in query execution
+tags: explain, analyze, diagnostics, query-plan
+---
+
+## Use EXPLAIN ANALYZE to Diagnose Slow Queries
+
+EXPLAIN ANALYZE executes the query and shows actual timings, revealing the true performance bottlenecks.
+
+**Incorrect (guessing at performance issues):**
+
+```sql
+-- Query is slow, but why?
+select * from orders where customer_id = 123 and status = 'pending';
+-- "It must be missing an index" - but which one?
+```
+
+**Correct (use EXPLAIN ANALYZE):**
+
+```sql
+explain (analyze, buffers, format text)
+select * from orders where customer_id = 123 and status = 'pending';
+
+-- Output reveals the issue:
+-- Seq Scan on orders (cost=0.00..25000.00 rows=50 width=100) (actual time=0.015..450.123 rows=50 loops=1)
+--   Filter: ((customer_id = 123) AND (status = 'pending'::text))
+--   Rows Removed by Filter: 999950
+--   Buffers: shared hit=5000 read=15000
+-- Planning Time: 0.150 ms
+-- Execution Time: 450.500 ms
+```
+
+Key things to look for:
+
+```sql
+-- Seq Scan on large tables = missing index
+-- Rows Removed by Filter = poor selectivity or missing index
+-- Buffers: read >> hit = data not cached, needs more memory
+-- Nested Loop with high loops = consider different join strategy
+-- Sort Method: external merge = work_mem too low
+```
+
+Reference: [EXPLAIN](https://supabase.com/docs/guides/database/inspect)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
@@ -1,0 +1,55 @@
+---
+title: Enable pg_stat_statements for Query Analysis
+impact: LOW-MEDIUM
+impactDescription: Identify top resource-consuming queries
+tags: pg-stat-statements, monitoring, statistics, performance
+---
+
+## Enable pg_stat_statements for Query Analysis
+
+pg_stat_statements tracks execution statistics for all queries, helping identify slow and frequent queries.
+
+**Incorrect (no visibility into query patterns):**
+
+```sql
+-- Database is slow, but which queries are the problem?
+-- No way to know without pg_stat_statements
+```
+
+**Correct (enable and query pg_stat_statements):**
+
+```sql
+-- Enable the extension
+create extension if not exists pg_stat_statements;
+
+-- Find slowest queries by total time
+select
+  calls,
+  round(total_exec_time::numeric, 2) as total_time_ms,
+  round(mean_exec_time::numeric, 2) as mean_time_ms,
+  query
+from pg_stat_statements
+order by total_exec_time desc
+limit 10;
+
+-- Find most frequent queries
+select calls, query
+from pg_stat_statements
+order by calls desc
+limit 10;
+
+-- Reset statistics after optimization
+select pg_stat_statements_reset();
+```
+
+Key metrics to monitor:
+
+```sql
+-- Queries with high mean time (candidates for optimization)
+select query, mean_exec_time, calls
+from pg_stat_statements
+where mean_exec_time > 100  -- > 100ms average
+order by mean_exec_time desc;
+```
+
+Reference: [pg_stat_statements](https://supabase.com/docs/guides/database/extensions/pg_stat_statements)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -1,0 +1,55 @@
+---
+title: Maintain Table Statistics with VACUUM and ANALYZE
+impact: MEDIUM
+impactDescription: 2-10x better query plans with accurate statistics
+tags: vacuum, analyze, statistics, maintenance, autovacuum
+---
+
+## Maintain Table Statistics with VACUUM and ANALYZE
+
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+
+**Incorrect (stale statistics):**
+
+```sql
+-- Table has 1M rows but stats say 1000
+-- Query planner chooses wrong strategy
+explain select * from orders where status = 'pending';
+-- Shows: Seq Scan (because stats show small table)
+-- Actually: Index Scan would be much faster
+```
+
+**Correct (maintain fresh statistics):**
+
+```sql
+-- Manually analyze after large data changes
+analyze orders;
+
+-- Analyze specific columns used in WHERE clauses
+analyze orders (status, created_at);
+
+-- Check when tables were last analyzed
+select
+  relname,
+  last_vacuum,
+  last_autovacuum,
+  last_analyze,
+  last_autoanalyze
+from pg_stat_user_tables
+order by last_analyze nulls first;
+```
+
+Autovacuum tuning for busy tables:
+
+```sql
+-- Increase frequency for high-churn tables
+alter table orders set (
+  autovacuum_vacuum_scale_factor = 0.05,     -- Vacuum at 5% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
+);
+
+-- Check autovacuum status
+select * from pg_stat_progress_vacuum;
+```
+
+Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
@@ -1,0 +1,44 @@
+---
+title: Create Composite Indexes for Multi-Column Queries
+impact: HIGH
+impactDescription: 5-10x faster multi-column queries
+tags: indexes, composite-index, multi-column, query-optimization
+---
+
+## Create Composite Indexes for Multi-Column Queries
+
+When queries filter on multiple columns, a composite index is more efficient than separate single-column indexes.
+
+**Incorrect (separate indexes require bitmap scan):**
+
+```sql
+-- Two separate indexes
+create index orders_status_idx on orders (status);
+create index orders_created_idx on orders (created_at);
+
+-- Query must combine both indexes (slower)
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Correct (composite index):**
+
+```sql
+-- Single composite index (leftmost column first for equality checks)
+create index orders_status_created_idx on orders (status, created_at);
+
+-- Query uses one efficient index scan
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Column order matters** - place equality columns first, range columns last:
+
+```sql
+-- Good: status (=) before created_at (>)
+create index idx on orders (status, created_at);
+
+-- Works for: WHERE status = 'pending'
+-- Works for: WHERE status = 'pending' AND created_at > '2024-01-01'
+-- Does NOT work for: WHERE created_at > '2024-01-01' (leftmost prefix rule)
+```
+
+Reference: [Multicolumn Indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
@@ -1,0 +1,40 @@
+---
+title: Use Covering Indexes to Avoid Table Lookups
+impact: MEDIUM-HIGH
+impactDescription: 2-5x faster queries by eliminating heap fetches
+tags: indexes, covering-index, include, index-only-scan
+---
+
+## Use Covering Indexes to Avoid Table Lookups
+
+Covering indexes include all columns needed by a query, enabling index-only scans that skip the table entirely.
+
+**Incorrect (index scan + heap fetch):**
+
+```sql
+create index users_email_idx on users (email);
+
+-- Must fetch name and created_at from table heap
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+**Correct (index-only scan with INCLUDE):**
+
+```sql
+-- Include non-searchable columns in the index
+create index users_email_idx on users (email) include (name, created_at);
+
+-- All columns served from index, no table access needed
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+Use INCLUDE for columns you SELECT but don't filter on:
+
+```sql
+-- Searching by status, but also need customer_id and total
+create index orders_status_idx on orders (status) include (customer_id, total);
+
+select status, customer_id, total from orders where status = 'shipped';
+```
+
+Reference: [Index-Only Scans](https://www.postgresql.org/docs/current/indexes-index-only-scans.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
@@ -1,0 +1,48 @@
+---
+title: Choose the Right Index Type for Your Data
+impact: HIGH
+impactDescription: 10-100x improvement with correct index type
+tags: indexes, btree, gin, gist, brin, hash, index-types
+---
+
+## Choose the Right Index Type for Your Data
+
+Different index types excel at different query patterns. The default B-tree isn't always optimal.
+
+**Incorrect (B-tree for JSONB containment):**
+
+```sql
+-- B-tree cannot optimize containment operators
+create index products_attrs_idx on products (attributes);
+select * from products where attributes @> '{"color": "red"}';
+-- Full table scan - B-tree doesn't support @> operator
+```
+
+**Correct (GIN for JSONB):**
+
+```sql
+-- GIN supports @>, ?, ?&, ?| operators
+create index products_attrs_idx on products using gin (attributes);
+select * from products where attributes @> '{"color": "red"}';
+```
+
+Index type guide:
+
+```sql
+-- B-tree (default): =, <, >, BETWEEN, IN, IS NULL
+create index users_created_idx on users (created_at);
+
+-- GIN: arrays, JSONB, full-text search
+create index posts_tags_idx on posts using gin (tags);
+
+-- GiST: geometric data, range types, nearest-neighbor (KNN) queries
+create index locations_idx on places using gist (location);
+
+-- BRIN: large time-series tables (10-100x smaller)
+create index events_time_idx on events using brin (created_at);
+
+-- Hash: equality-only (slightly faster than B-tree for =)
+create index sessions_token_idx on sessions using hash (token);
+```
+
+Reference: [Index Types](https://www.postgresql.org/docs/current/indexes-types.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
@@ -1,0 +1,43 @@
+---
+title: Add Indexes on WHERE and JOIN Columns
+impact: CRITICAL
+impactDescription: 100-1000x faster queries on large tables
+tags: indexes, performance, sequential-scan, query-optimization
+---
+
+## Add Indexes on WHERE and JOIN Columns
+
+Queries filtering or joining on unindexed columns cause full table scans, which become exponentially slower as tables grow.
+
+**Incorrect (sequential scan on large table):**
+
+```sql
+-- No index on customer_id causes full table scan
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Seq Scan on orders (cost=0.00..25000.00 rows=100 width=85)
+```
+
+**Correct (index scan):**
+
+```sql
+-- Create index on frequently filtered column
+create index orders_customer_id_idx on orders (customer_id);
+
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Index Scan using orders_customer_id_idx (cost=0.42..8.44 rows=100 width=85)
+```
+
+For JOIN columns, always index the foreign key side:
+
+```sql
+-- Index the referencing column
+create index orders_customer_id_idx on orders (customer_id);
+
+select c.name, o.total
+from customers c
+join orders o on o.customer_id = c.id;
+```
+
+Reference: [Query Optimization](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
@@ -1,0 +1,45 @@
+---
+title: Use Partial Indexes for Filtered Queries
+impact: HIGH
+impactDescription: 5-20x smaller indexes, faster writes and queries
+tags: indexes, partial-index, query-optimization, storage
+---
+
+## Use Partial Indexes for Filtered Queries
+
+Partial indexes only include rows matching a WHERE condition, making them smaller and faster when queries consistently filter on the same condition.
+
+**Incorrect (full index includes irrelevant rows):**
+
+```sql
+-- Index includes all rows, even soft-deleted ones
+create index users_email_idx on users (email);
+
+-- Query always filters active users
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+**Correct (partial index matches query filter):**
+
+```sql
+-- Index only includes active users
+create index users_active_email_idx on users (email)
+where deleted_at is null;
+
+-- Query uses the smaller, faster index
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+Common use cases for partial indexes:
+
+```sql
+-- Only pending orders (status rarely changes once completed)
+create index orders_pending_idx on orders (created_at)
+where status = 'pending';
+
+-- Only non-null values
+create index products_sku_idx on products (sku)
+where sku is not null;
+```
+
+Reference: [Partial Indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
@@ -1,0 +1,80 @@
+---
+title: Add Constraints Safely in Migrations
+impact: HIGH
+impactDescription: Prevents migration failures and enables idempotent schema changes
+tags: constraints, migrations, schema, alter-table
+---
+
+## Add Constraints Safely in Migrations
+
+PostgreSQL does not support `ADD CONSTRAINT IF NOT EXISTS`. Migrations using this syntax will fail.
+
+**Incorrect (causes syntax error):**
+
+```sql
+-- ERROR: syntax error at or near "not" (SQLSTATE 42601)
+alter table public.profiles
+add constraint if not exists profiles_birthchart_id_unique unique (birthchart_id);
+```
+
+**Correct (idempotent constraint creation):**
+
+```sql
+-- Use DO block to check before adding
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_unique'
+    and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+    add constraint profiles_birthchart_id_unique unique (birthchart_id);
+  end if;
+end $$;
+```
+
+For all constraint types:
+
+```sql
+-- Check constraints
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'check_age_positive'
+  ) then
+    alter table users add constraint check_age_positive check (age > 0);
+  end if;
+end $$;
+
+-- Foreign keys
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_fkey'
+  ) then
+    alter table profiles
+    add constraint profiles_birthchart_id_fkey
+    foreign key (birthchart_id) references birthcharts(id);
+  end if;
+end $$;
+```
+
+Check if constraint exists:
+
+```sql
+-- Query to check constraint existence
+select conname, contype, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.profiles'::regclass;
+
+-- contype values:
+-- 'p' = PRIMARY KEY
+-- 'f' = FOREIGN KEY
+-- 'u' = UNIQUE
+-- 'c' = CHECK
+```
+
+Reference: [Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
@@ -1,0 +1,46 @@
+---
+title: Choose Appropriate Data Types
+impact: HIGH
+impactDescription: 50% storage reduction, faster comparisons
+tags: data-types, schema, storage, performance
+---
+
+## Choose Appropriate Data Types
+
+Using the right data types reduces storage, improves query performance, and prevents bugs.
+
+**Incorrect (wrong data types):**
+
+```sql
+create table users (
+  id int,                    -- Will overflow at 2.1 billion
+  email varchar(255),        -- Unnecessary length limit
+  created_at timestamp,      -- Missing timezone info
+  is_active varchar(5),      -- String for boolean
+  price varchar(20)          -- String for numeric
+);
+```
+
+**Correct (appropriate data types):**
+
+```sql
+create table users (
+  id bigint generated always as identity primary key,  -- 9 quintillion max
+  email text,                     -- No artificial limit, same performance as varchar
+  created_at timestamptz,         -- Always store timezone-aware timestamps
+  is_active boolean default true, -- 1 byte vs variable string length
+  price numeric(10,2)             -- Exact decimal arithmetic
+);
+```
+
+Key guidelines:
+
+```sql
+-- IDs: use bigint, not int (future-proofing)
+-- Strings: use text, not varchar(n) unless constraint needed
+-- Time: use timestamptz, not timestamp
+-- Money: use numeric, not float (precision matters)
+-- Enums: use text with check constraint or create enum type
+```
+
+Reference: [Data Types](https://www.postgresql.org/docs/current/datatype.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
@@ -1,0 +1,59 @@
+---
+title: Index Foreign Key Columns
+impact: HIGH
+impactDescription: 10-100x faster JOINs and CASCADE operations
+tags: foreign-key, indexes, joins, schema
+---
+
+## Index Foreign Key Columns
+
+Postgres does not automatically index foreign key columns. Missing indexes cause slow JOINs and CASCADE operations.
+
+**Incorrect (unindexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- No index on customer_id!
+-- JOINs and ON DELETE CASCADE both require full table scan
+select * from orders where customer_id = 123;  -- Seq Scan
+delete from customers where id = 123;          -- Locks table, scans all orders
+```
+
+**Correct (indexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- Always index the FK column
+create index orders_customer_id_idx on orders (customer_id);
+
+-- Now JOINs and cascades are fast
+select * from orders where customer_id = 123;  -- Index Scan
+delete from customers where id = 123;          -- Uses index, fast cascade
+```
+
+Find missing FK indexes:
+
+```sql
+select
+  conrelid::regclass as table_name,
+  a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+Reference: [Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
@@ -1,0 +1,55 @@
+---
+title: Use Lowercase Identifiers for Compatibility
+impact: MEDIUM
+impactDescription: Avoid case-sensitivity bugs with tools, ORMs, and AI assistants
+tags: naming, identifiers, case-sensitivity, schema, conventions
+---
+
+## Use Lowercase Identifiers for Compatibility
+
+PostgreSQL folds unquoted identifiers to lowercase. Quoted mixed-case identifiers require quotes forever and cause issues with tools, ORMs, and AI assistants that may not recognize them.
+
+**Incorrect (mixed-case identifiers):**
+
+```sql
+-- Quoted identifiers preserve case but require quotes everywhere
+CREATE TABLE "Users" (
+  "userId" bigint PRIMARY KEY,
+  "firstName" text,
+  "lastName" text
+);
+
+-- Must always quote or queries fail
+SELECT "firstName" FROM "Users" WHERE "userId" = 1;
+
+-- This fails - Users becomes users without quotes
+SELECT firstName FROM Users;
+-- ERROR: relation "users" does not exist
+```
+
+**Correct (lowercase snake_case):**
+
+```sql
+-- Unquoted lowercase identifiers are portable and tool-friendly
+CREATE TABLE users (
+  user_id bigint PRIMARY KEY,
+  first_name text,
+  last_name text
+);
+
+-- Works without quotes, recognized by all tools
+SELECT first_name FROM users WHERE user_id = 1;
+```
+
+Common sources of mixed-case identifiers:
+
+```sql
+-- ORMs often generate quoted camelCase - configure them to use snake_case
+-- Migrations from other databases may preserve original casing
+-- Some GUI tools quote identifiers by default - disable this
+
+-- If stuck with mixed-case, create views as a compatibility layer
+CREATE VIEW users AS SELECT "userId" AS user_id, "firstName" AS first_name FROM "Users";
+```
+
+Reference: [Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
@@ -1,0 +1,55 @@
+---
+title: Partition Large Tables for Better Performance
+impact: MEDIUM-HIGH
+impactDescription: 5-20x faster queries and maintenance on large tables
+tags: partitioning, large-tables, time-series, performance
+---
+
+## Partition Large Tables for Better Performance
+
+Partitioning splits a large table into smaller pieces, improving query performance and maintenance operations.
+
+**Incorrect (single large table):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz,
+  data jsonb
+);
+
+-- 500M rows, queries scan everything
+select * from events where created_at > '2024-01-01';  -- Slow
+vacuum events;  -- Takes hours, locks table
+```
+
+**Correct (partitioned by time range):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz not null,
+  data jsonb
+) partition by range (created_at);
+
+-- Create partitions for each month
+create table events_2024_01 partition of events
+  for values from ('2024-01-01') to ('2024-02-01');
+
+create table events_2024_02 partition of events
+  for values from ('2024-02-01') to ('2024-03-01');
+
+-- Queries only scan relevant partitions
+select * from events where created_at > '2024-01-15';  -- Only scans events_2024_01+
+
+-- Drop old data instantly
+drop table events_2023_01;  -- Instant vs DELETE taking hours
+```
+
+When to partition:
+
+- Tables > 100M rows
+- Time-series data with date-based queries
+- Need to efficiently drop old data
+
+Reference: [Table Partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
@@ -1,0 +1,61 @@
+---
+title: Select Optimal Primary Key Strategy
+impact: HIGH
+impactDescription: Better index locality, reduced fragmentation
+tags: primary-key, identity, uuid, serial, schema
+---
+
+## Select Optimal Primary Key Strategy
+
+Primary key choice affects insert performance, index size, and replication
+efficiency.
+
+**Incorrect (problematic PK choices):**
+
+```sql
+-- identity is the SQL-standard approach
+create table users (
+  id serial primary key  -- Works, but IDENTITY is recommended
+);
+
+-- Random UUIDs (v4) cause index fragmentation
+create table orders (
+  id uuid default gen_random_uuid() primary key  -- UUIDv4 = random = scattered inserts
+);
+```
+
+**Correct (optimal PK strategies):**
+
+```sql
+-- Use IDENTITY for sequential IDs (SQL-standard, best for most cases)
+create table users (
+  id bigint generated always as identity primary key
+);
+
+-- For distributed systems needing UUIDs, use UUIDv7 (time-ordered)
+-- Requires pg_uuidv7 extension: create extension pg_uuidv7;
+create table orders (
+  id uuid default uuid_generate_v7() primary key  -- Time-ordered, no fragmentation
+);
+
+-- Alternative: time-prefixed IDs for sortable, distributed IDs (no extension needed)
+create table events (
+  id text default concat(
+    to_char(now() at time zone 'utc', 'YYYYMMDDHH24MISSMS'),
+    gen_random_uuid()::text
+  ) primary key
+);
+```
+
+Guidelines:
+
+- Single database: `bigint identity` (sequential, 8 bytes, SQL-standard)
+- Distributed/exposed IDs: UUIDv7 (requires pg_uuidv7) or ULID (time-ordered, no
+  fragmentation)
+- `serial` works but `identity` is SQL-standard and preferred for new
+  applications
+- Avoid random UUIDs (v4) as primary keys on large tables (causes index
+  fragmentation)
+
+Reference:
+[Identity Columns](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-GENERATED-IDENTITY)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
@@ -1,0 +1,54 @@
+---
+title: Apply Principle of Least Privilege
+impact: MEDIUM
+impactDescription: Reduced attack surface, better audit trail
+tags: privileges, security, roles, permissions
+---
+
+## Apply Principle of Least Privilege
+
+Grant only the minimum permissions required. Never use superuser for application queries.
+
+**Incorrect (overly broad permissions):**
+
+```sql
+-- Application uses superuser connection
+-- Or grants ALL to application role
+grant all privileges on all tables in schema public to app_user;
+grant all privileges on all sequences in schema public to app_user;
+
+-- Any SQL injection becomes catastrophic
+-- drop table users; cascades to everything
+```
+
+**Correct (minimal, specific grants):**
+
+```sql
+-- Create role with no default privileges
+create role app_readonly nologin;
+
+-- Grant only SELECT on specific tables
+grant usage on schema public to app_readonly;
+grant select on public.products, public.categories to app_readonly;
+
+-- Create role for writes with limited scope
+create role app_writer nologin;
+grant usage on schema public to app_writer;
+grant select, insert, update on public.orders to app_writer;
+grant usage on sequence orders_id_seq to app_writer;
+-- No DELETE permission
+
+-- Login role inherits from these
+create role app_user login password 'xxx';
+grant app_writer to app_user;
+```
+
+Revoke public defaults:
+
+```sql
+-- Revoke default public access
+revoke all on schema public from public;
+revoke all on all tables in schema public from public;
+```
+
+Reference: [Roles and Privileges](https://supabase.com/blog/postgres-roles-and-privileges)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,0 +1,50 @@
+---
+title: Enable Row Level Security for Multi-Tenant Data
+impact: CRITICAL
+impactDescription: Database-enforced tenant isolation, prevent data leaks
+tags: rls, row-level-security, multi-tenant, security
+---
+
+## Enable Row Level Security for Multi-Tenant Data
+
+Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+
+**Incorrect (application-level filtering only):**
+
+```sql
+-- Relying only on application to filter
+select * from orders where user_id = $current_user_id;
+
+-- Bug or bypass means all data is exposed!
+select * from orders;  -- Returns ALL orders
+```
+
+**Correct (database-enforced RLS):**
+
+```sql
+-- Enable RLS on the table
+alter table orders enable row level security;
+
+-- Create policy for users to see only their orders
+create policy orders_user_policy on orders
+  for all
+  using (user_id = current_setting('app.current_user_id')::bigint);
+
+-- Force RLS even for table owners
+alter table orders force row level security;
+
+-- Set user context and query
+set app.current_user_id = '123';
+select * from orders;  -- Only returns orders for user 123
+```
+
+Policy for authenticated role:
+
+```sql
+create policy orders_user_policy on orders
+  for all
+  to authenticated
+  using (user_id = auth.uid());
+```
+
+Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -1,0 +1,63 @@
+---
+title: Optimize RLS Policies for Performance
+impact: HIGH
+impactDescription: 5-10x faster RLS queries with proper patterns
+tags: rls, performance, security, optimization
+---
+
+## Optimize RLS Policies for Performance
+
+Poorly written RLS policies can cause severe performance issues. Use subqueries and indexes strategically.
+
+**Incorrect (function called for every row):**
+
+```sql
+create policy orders_policy on orders
+  using (auth.uid() = user_id);  -- auth.uid() called per row!
+
+-- With 1M rows, auth.uid() is called 1M times
+```
+
+**Correct (wrap functions in SELECT):**
+
+```sql
+create policy orders_policy on orders
+  using ((select auth.uid()) = user_id);  -- Called once, cached
+
+-- 100x+ faster on large tables
+```
+
+Use security definer functions for complex checks:
+
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
+
+```sql
+-- Create helper function in a private schema
+create or replace function private.is_team_member(team_id bigint)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.team_members
+    -- always check the calling user's identity inside the function
+    where team_id = $1 and user_id = (select auth.uid())
+  );
+$$;
+
+-- Revoke direct execution from public roles
+revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
+
+-- Use in policy (indexed lookup, not per-row check)
+create policy team_orders_policy on orders
+  using ((select private.is_team_member(team_id)));
+```
+
+Always add indexes on columns used in RLS policies:
+
+```sql
+create index orders_user_id_idx on orders (user_id);
+```
+
+Reference: [RLS Performance](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations)

--- a/.agents/skills/supabase/CHANGELOG.md
+++ b/.agents/skills/supabase/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## [0.1.4](https://github.com/supabase/agent-skills/compare/v0.1.3...v0.1.4) (2026-06-05)
+
+
+### Features
+
+* add instructions to check changelog ([#74](https://github.com/supabase/agent-skills/issues/74)) ([4bb13d8](https://github.com/supabase/agent-skills/commit/4bb13d858d19f1f848505a66f46fc9603fdcde95))
+* add npm supply-chain security guidance to supabase skill ([#94](https://github.com/supabase/agent-skills/issues/94)) ([82df90a](https://github.com/supabase/agent-skills/commit/82df90a5de1cd84386d8bc192746e50343b86dc0))
+* instructions on exposing tables to the data api ([#71](https://github.com/supabase/agent-skills/issues/71)) ([f15a5a4](https://github.com/supabase/agent-skills/commit/f15a5a40779072a530c9e53c3f14ec4131118ea6))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* bump supabase skill to v0.1.1 and fix Data API broken link ([#72](https://github.com/supabase/agent-skills/issues/72)) ([5a6542e](https://github.com/supabase/agent-skills/commit/5a6542e08fc026d90c9a6a0f5a67749e9ceb9946))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+* update Data API doc link and bump supabase skill to v0.1.1 ([#73](https://github.com/supabase/agent-skills/issues/73)) ([e5f7a7c](https://github.com/supabase/agent-skills/commit/e5f7a7cfd697765848ffd6a4505f3c02e1ee17ee))
+
+## [0.1.3](https://github.com/supabase/agent-skills/compare/v0.1.2...v0.1.3) (2026-06-02)
+
+
+### Features
+
+* add instructions to check changelog ([#74](https://github.com/supabase/agent-skills/issues/74)) ([4bb13d8](https://github.com/supabase/agent-skills/commit/4bb13d858d19f1f848505a66f46fc9603fdcde95))
+* add npm supply-chain security guidance to supabase skill ([#94](https://github.com/supabase/agent-skills/issues/94)) ([82df90a](https://github.com/supabase/agent-skills/commit/82df90a5de1cd84386d8bc192746e50343b86dc0))
+* instructions on exposing tables to the data api ([#71](https://github.com/supabase/agent-skills/issues/71)) ([f15a5a4](https://github.com/supabase/agent-skills/commit/f15a5a40779072a530c9e53c3f14ec4131118ea6))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* bump supabase skill to v0.1.1 and fix Data API broken link ([#72](https://github.com/supabase/agent-skills/issues/72)) ([5a6542e](https://github.com/supabase/agent-skills/commit/5a6542e08fc026d90c9a6a0f5a67749e9ceb9946))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+* update Data API doc link and bump supabase skill to v0.1.1 ([#73](https://github.com/supabase/agent-skills/issues/73)) ([e5f7a7c](https://github.com/supabase/agent-skills/commit/e5f7a7cfd697765848ffd6a4505f3c02e1ee17ee))

--- a/.agents/skills/supabase/SKILL.md
+++ b/.agents/skills/supabase/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: supabase
+description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
+metadata:
+  author: supabase
+  version: "0.1.2"
+---
+
+# Supabase
+
+## Core Principles
+
+**1. Supabase changes frequently — verify against changelog and current docs before implementing.**
+Do not rely on training data for Supabase features. Function signatures, config.toml settings, and API conventions change between versions.
+
+First, fetch `https://supabase.com/changelog.md` (a lightweight summary index — not a heavy pull), scan for `breaking-change` tags relevant to your task, and follow the linked page for any that apply. Then look up the relevant topic using the documentation access methods below.
+
+**2. Verify your work.**
+After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
+
+**3. Recover from errors, don't loop.**
+If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
+
+**4. Exposing tables to the Data API:** Depending on the user's [Data API settings](https://supabase.com/dashboard/project/<ref>/integrations/data_api/settings), newly created tables may not be automatically exposed via the Data (REST) API. If this is the case, `anon` and `authenticated` roles will need to be explicitly granted access.
+
+> Note that this is separate from RLS, which controls which _rows_ are visible once a table is accessible, not whether the table is accessible at all.
+
+When a user reports a SQL-created table is unexpectedly inaccessible, check their Data API settings and whether the roles have been granted access via explicit `GRANT` SQL. When granting public (`anon`/`authenticated`) access, always enable RLS too. See [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md) for the full setup workflow.
+
+**5. RLS in exposed schemas.**
+Enable RLS on every table in any exposed schema, which includes `public` by default. This is critical in Supabase because tables in exposed schemas can be reachable through the Data API when the `anon`/`authenticated` roles have access (see [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md)). For private schemas, prefer RLS as defense in depth. After enabling RLS, create policies that match the actual access model rather than defaulting every table to the same `auth.uid()` pattern.
+
+**6. Security checklist.**
+When working on any Supabase task that touches auth, RLS, views, storage, or user data, run through this checklist. These are Supabase-specific security traps that silently create vulnerabilities:
+
+- **Auth and session security**
+  - **Never use `user_metadata` claims in JWT-based authorization decisions.** In Supabase, `raw_user_meta_data` is user-editable and can appear in `auth.jwt()`, so it is unsafe for RLS policies or any other authorization logic. Store authorization data in `raw_app_meta_data` / `app_metadata` instead.
+  - **Deleting a user does not invalidate existing access tokens.** Sign out or revoke sessions first, keep JWT expiry short for sensitive apps, and for strict guarantees validate `session_id` against `auth.sessions` on sensitive operations.
+  - **If you use `app_metadata` or `auth.jwt()` for authorization, remember JWT claims are not always fresh until the user's token is refreshed.**
+
+- **API key and client exposure**
+  - **Never expose the `service_role` or secret key in public clients.** Prefer publishable keys for frontend code. Legacy `anon` keys are only for compatibility. In Next.js, any `NEXT_PUBLIC_` env var is sent to the browser.
+
+- **RLS, views, and privileged database code**
+  - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
+  - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
+  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in.
+    ```sql
+    -- Deprecated (do not use)
+    create policy "example" on table_name for select
+    using ( auth.role() = 'authenticated' );
+    ```
+  - **`TO authenticated` alone is authentication without authorization (BOLA / IDOR).** Using `TO authenticated` only checks the role — it does not restrict which rows a user can access. The correct pattern combines `TO authenticated` with an ownership predicate in `USING`:
+    ```sql
+    create policy "example" on table_name for select
+    to authenticated
+    using ( (select auth.uid()) = user_id );
+    ```
+  - **UPDATE policies require both `USING` and `WITH CHECK`.** Without `WITH CHECK`, a user can reassign a row's `user_id` to another user:
+    ```sql
+    create policy "example" on table_name for update
+    to authenticated
+    using ( (select auth.uid()) = user_id )
+    with check ( (select auth.uid()) = user_id );
+    ```
+  - **`SECURITY DEFINER` functions bypass RLS.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a role with `bypassrls` (e.g., `postgres`). Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`.
+  - **`SECURITY DEFINER` functions in `public` are callable by all roles.** Postgres grants `EXECUTE` to `PUBLIC` by default for every new function, so any `SECURITY DEFINER` function in `public` is a public API endpoint callable by `anon` and `authenticated` (which inherit from `PUBLIC`) without any additional grant. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema, always include an `auth.uid()` check in the function body, and run `supabase db advisors` after making changes.
+
+- **Storage access control**
+  - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.
+
+- **Dependency and supply-chain security**
+  - **Always pin package versions and commit lockfiles** when installing Supabase packages (`supabase-js`, `@supabase/ssr`, `supabase-py`, etc.). See the [npm security guide](https://supabase.com/docs/guides/security/npm-security.md) for the full checklist.
+
+For any security concern not covered above, fetch the Supabase product security index: `https://supabase.com/docs/guides/security/product-security.md`
+
+## Supabase CLI
+
+Always discover commands via `--help` — never guess. The CLI structure changes between versions.
+
+```bash
+supabase --help                    # All top-level commands
+supabase <group> --help            # Subcommands (e.g., supabase db --help)
+supabase <group> <command> --help  # Flags for a specific command
+```
+
+**Supabase CLI Known gotchas:**
+
+- `supabase db query` requires **CLI v2.79.0+** → use MCP `execute_sql` or `psql` as fallback
+- `supabase db advisors` requires **CLI v2.81.3+** → use MCP `get_advisors` as fallback
+- When you need a new migration SQL file, **always** create it with `supabase migration new <name>` first. Never invent a migration filename or rely on memory for the expected format.
+
+**Version check and upgrade:** Run `supabase --version` to check. For CLI changelogs and version-specific features, consult the [CLI documentation](https://supabase.com/docs/reference/cli/introduction) or [GitHub releases](https://github.com/supabase/cli/releases).
+
+## Supabase MCP Server
+
+For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
+
+**Troubleshooting connection issues** — follow these steps in order:
+
+1. **Check if the server is reachable:**
+   `curl -so /dev/null -w "%{http_code}" https://mcp.supabase.com/mcp`
+   A `401` is expected (no token) and means the server is up. Timeout or "connection refused" means it may be down.
+
+2. **Check `.mcp.json` configuration:**
+   Verify the project root has a valid `.mcp.json` with the correct server URL. If missing, create one pointing to `https://mcp.supabase.com/mcp`.
+
+3. **Authenticate the MCP server:**
+   If the server is reachable and `.mcp.json` is correct but tools aren't visible, the user needs to authenticate. The Supabase MCP server uses OAuth 2.1 — tell the user to trigger the auth flow in their agent, complete it in the browser, and reload the session.
+
+## Supabase Documentation
+
+Before implementing any Supabase feature, find the relevant documentation. Use these methods in priority order:
+
+1. **MCP `search_docs` tool** (preferred — returns relevant snippets directly)
+2. **Fetch docs pages as markdown** — any docs page can be fetched by appending `.md` to the URL path.
+3. **Web search** for Supabase-specific topics when you don't know which page to look at.
+
+## Making and Committing Schema Changes
+
+**To make schema changes, use `execute_sql` (MCP) or `supabase db query` (CLI).** These run SQL directly on the database without creating migration history entries, so you can iterate freely and generate a clean migration when ready.
+
+Do NOT use `apply_migration` to change a local database schema — it writes a migration history entry on every call, which means you can't iterate, and `supabase db diff` / `supabase db pull` will produce empty or conflicting diffs. If you use it, you'll be stuck with whatever SQL you passed on the first try.
+
+**When ready to commit** your changes to a migration file:
+
+1. **Run advisors** → `supabase db advisors` (CLI v2.81.3+) or MCP `get_advisors`. Fix any issues.
+2. **Review the Security Checklist above** if your changes involve views, functions, triggers, or storage.
+3. **Generate the migration** → `supabase db pull <descriptive-name> --local --yes`
+4. **Verify** → `supabase migration list --local`
+
+## Reference Guides
+
+- **Skill Feedback** → [references/skill-feedback.md](references/skill-feedback.md)
+  **MUST read when** the user reports that this skill gave incorrect guidance or is missing information.

--- a/.agents/skills/supabase/assets/feedback-issue-template.md
+++ b/.agents/skills/supabase/assets/feedback-issue-template.md
@@ -1,0 +1,17 @@
+## What happened
+
+**Task:** <!-- e.g., "Set up MFA on patient records" -->
+
+**Skill said:** <!-- e.g., "Use auth.jwt()->'app_metadata' in the RLS policy" -->
+
+**Expected:** <!-- e.g., "The function also needs SECURITY DEFINER + grant to supabase_auth_admin" -->
+
+## Source
+
+**File:** <!-- e.g., references/security-model.md -->
+
+**Section:** <!-- e.g., "Trust Boundaries > user_metadata vs app_metadata" -->
+
+## Fix suggestion
+
+<!-- Leave blank if unsure -->

--- a/.agents/skills/supabase/references/skill-feedback.md
+++ b/.agents/skills/supabase/references/skill-feedback.md
@@ -1,0 +1,17 @@
+# Skill Feedback
+
+Use this when the user reports that the skill gave incorrect guidance, is missing information, or could be improved. This is about the skill (agent instructions), not about Supabase the product.
+
+## Steps
+
+1. **Ask permission** — Ask the user if they'd like to submit feedback to the skill maintainers. If they decline, move on.
+
+2. **Draft the issue** — Use the template at [assets/feedback-issue-template.md](../assets/feedback-issue-template.md) to structure the feedback. Fill in the fields based on the conversation. Always identify which specific reference file and section caused the problem.
+
+3. **Submit** — Create a GitHub Issue on the `supabase/agent-skills` repository using the draft as the issue body. The title must follow this format: `user-feedback: <summary of the problem>`.
+
+4. **Share the result** — Share the issue URL with the user after submission. If submission fails, give the user this link to create the issue manually:
+
+```
+https://github.com/supabase/agent-skills/issues/new
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=bhxkhpszeeblchomppse"
+    }
+  }
+}

--- a/.claude/skills/supabase
+++ b/.claude/skills/supabase
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase

--- a/.claude/skills/supabase-postgres-best-practices
+++ b/.claude/skills/supabase-postgres-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase-postgres-best-practices

--- a/README.md
+++ b/README.md
@@ -286,19 +286,54 @@ Default local URL:
 Available endpoints:
 
 - `GET /health`
-- `POST /chat`
+- `POST /runtime/request` - main v1 mission-aware runtime contract
+- `POST /chat` - legacy compatibility chat endpoint
 
 Example calls:
 
 ```bash
 curl -s http://127.0.0.1:8000/health
-curl -s -X POST http://127.0.0.1:8000/chat \
+curl -s -X POST http://127.0.0.1:8000/runtime/request \
   -H "Content-Type: application/json" \
-  -d '{"message":"hello"}'
+  -d '{
+    "user_id": "u_123",
+    "mission_id": "aero",
+    "session_id": "sess_abc123",
+    "operation": "chat",
+    "message": "hello",
+    "write_intent": null
+  }'
+
+curl -s -X POST http://127.0.0.1:8000/runtime/request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "u_123",
+    "mission_id": "aero",
+    "session_id": "sess_abc123",
+    "operation": "write_intent",
+    "message": "Mark payload power verification complete.",
+    "write_intent": {
+      "operation": "checklist_item_set_status",
+      "mission_id": "aero",
+      "target_file": "missions/aero/checklists/preflight.md",
+      "item_id": "payload-power-verification",
+      "new_status": "done"
+    }
+  }'
 ```
+
+`POST /runtime/request` trust model:
+
+- The v1 request contract explicitly carries `user_id`, `mission_id`, `session_id`, and `operation`.
+- Client-supplied `history` is rejected on this endpoint; browser transcript state is not authoritative mission context.
+- STRATOS owns the runtime context envelope. Mission document loading is a follow-up, but the boundary is server-owned from this contract onward.
+- Until authentication middleware exists, request-body `user_id` is contract input only. It must not be treated as authorization for mission access or shared writes.
+- Structured write intents are validated for allowed operation names and mission-local target paths. They return `write_result.status="validated"` and do not mutate shared mission files until the mission workspace writer/review model is implemented.
+- Runtime responses include `response`, `source`, `session_id`, `mission_id`, `tool_calls`, `trajectory_artifact`, and `write_result`.
 
 `POST /chat` trust model:
 
+- `/chat` remains available as a compatibility endpoint for older callers.
 - Client-supplied `history` is treated as untrusted transcript input only.
 - The backend sanitizes prior history down to plain `role` and `content`.
 - Client-supplied prior `tool_calls` are ignored and never treated as authoritative state.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,16 @@
+.venv*
+venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.env
+.env.*
+.cache/
+logs/
+*.sqlite3
+out.csv*
+out.json
+out.kml
+out.kmz

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,7 @@ LAMINAR_USER_KEY="your_laminar_user_key_here"
 
 # SondeHub trajectory prediction
 SONDEHUB_TAWHIRI_ENDPOINT="https://api.v2.sondehub.org/tawhiri"
+
+# Supabase (managed backend)
+SUPABASE_URL="https://bhxkhpszeeblchomppse.supabase.co"
+SUPABASE_SERVICE_KEY="your_service_role_key_here"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import Header, HTTPException, status
+
+from app.supabase_client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+async def get_current_user_id(authorization: str = Header(None)) -> str:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"error": "Missing or invalid Authorization header."},
+        )
+    token = authorization.split(" ", 1)[1]
+    try:
+        response = get_supabase().auth.get_user(token)
+        return str(response.user.id)
+    except Exception:
+        logger.warning("JWT validation failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"error": "Invalid or expired token."},
+        )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,8 @@ class Settings:
     faa_client_secret: str
     laminar_user_key: str
     astra_gfs_cache_dir: str
+    supabase_url: str
+    supabase_service_key: str
 
 
 @lru_cache(maxsize=1)
@@ -46,4 +48,6 @@ def get_settings() -> Settings:
             "ASTRA_GFS_CACHE_DIR",
             str(default_astra_cache_dir),
         ),
+        supabase_url=os.getenv("SUPABASE_URL", ""),
+        supabase_service_key=os.getenv("SUPABASE_SERVICE_KEY", ""),
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,9 +30,7 @@ from app.schemas import (
     ChatResponse,
     McpToolGroupId,
     RuntimeRequest,
-    RuntimeRequestContext,
     RuntimeResponse,
-    RuntimeSharedContext,
     TrajectoryArtifact,
     ToolCallRecord,
     WriteResult,
@@ -186,7 +184,7 @@ def _validation_error_details(exc: ValidationError) -> list[dict]:
         return exc.errors()
 
 
-async def _parse_chat_request(request: Request) -> ChatRequest:
+async def _parse_raw_payload(request: Request, label: str) -> dict:
     raw_body = await _read_limited_body(request)
 
     try:
@@ -194,29 +192,31 @@ async def _parse_chat_request(request: Request) -> ChatRequest:
     except json.JSONDecodeError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error": "Chat request body must be valid JSON."},
+            detail={"error": f"{label} body must be valid JSON."},
         ) from exc
     except RecursionError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error": "Chat request JSON is too deeply nested."},
+            detail={"error": f"{label} JSON is too deeply nested."},
         ) from exc
 
     if not isinstance(raw_payload, dict):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"error": "Chat request body must be a JSON object."},
+            detail={"error": f"{label} body must be a JSON object."},
         )
 
     if not _within_json_depth(raw_payload):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "error": "Chat request JSON is too deeply nested.",
-                "limit_depth": CHAT_PAYLOAD_MAX_DEPTH,
-            },
+            detail={"error": f"{label} JSON is too deeply nested.", "limit_depth": CHAT_PAYLOAD_MAX_DEPTH},
         )
 
+    return raw_payload
+
+
+async def _parse_chat_request(request: Request) -> ChatRequest:
+    raw_payload = await _parse_raw_payload(request, "Chat request")
     try:
         return ChatRequest.model_validate(raw_payload)
     except ValidationError as exc:
@@ -230,36 +230,7 @@ async def _parse_chat_request(request: Request) -> ChatRequest:
 
 
 async def _parse_runtime_request(request: Request) -> RuntimeRequest:
-    raw_body = await _read_limited_body(request)
-
-    try:
-        raw_payload = json.loads(raw_body)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error": "Runtime request body must be valid JSON."},
-        ) from exc
-    except RecursionError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error": "Runtime request JSON is too deeply nested."},
-        ) from exc
-
-    if not isinstance(raw_payload, dict):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"error": "Runtime request body must be a JSON object."},
-        )
-
-    if not _within_json_depth(raw_payload):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "error": "Runtime request JSON is too deeply nested.",
-                "limit_depth": CHAT_PAYLOAD_MAX_DEPTH,
-            },
-        )
-
+    raw_payload = await _parse_raw_payload(request, "Runtime request")
     try:
         return RuntimeRequest.model_validate(raw_payload)
     except ValidationError as exc:
@@ -343,9 +314,11 @@ def _record_latest_chat_usage(
     llm_steps: int,
     llm_usage: list[dict[str, object]],
     request_started_at: float,
+    usage_source: str = "chat",
 ) -> ChatResponse:
     write_latest_chat_usage(
         {
+            "usage_source": usage_source,
             "request": {
                 "enabled_tool_groups": payload.enabled_tool_groups,
                 "history_items": len(payload.history),
@@ -373,41 +346,26 @@ def _record_latest_chat_usage(
     return response
 
 
-def _build_runtime_context(payload: RuntimeRequest) -> RuntimeRequestContext:
-    return RuntimeRequestContext(
-        user_id=payload.user_id,
-        mission_id=payload.mission_id,
-        session_id=payload.session_id,
-        operation=payload.operation,
-        message=payload.message,
-        write_intent=payload.write_intent,
-        shared_context=RuntimeSharedContext(),
-    )
-
-
 def _to_runtime_response(
     *,
-    context: RuntimeRequestContext,
+    payload: RuntimeRequest,
     chat_response: ChatResponse,
 ) -> RuntimeResponse:
     return RuntimeResponse(
         response=chat_response.response,
         source=RUNTIME_RESPONSE_SOURCE,
-        session_id=context.session_id,
-        mission_id=context.mission_id,
+        session_id=payload.session_id,
+        mission_id=payload.mission_id,
         tool_calls=chat_response.tool_calls,
         trajectory_artifact=chat_response.trajectory_artifact,
         write_result=None,
     )
 
 
-def _write_intent_validated_response(context: RuntimeRequestContext) -> RuntimeResponse:
-    if context.write_intent is None:
-        raise ValueError("Runtime write intent context is missing write_intent.")
-
+def _write_intent_validated_response(payload: RuntimeRequest) -> RuntimeResponse:
     write_result = WriteResult(
-        operation=context.write_intent.operation,
-        target_file=context.write_intent.target_file,
+        operation=payload.write_intent.operation,  # type: ignore[union-attr]
+        target_file=payload.write_intent.target_file,  # type: ignore[union-attr]
         summary=(
             "Validated structured write intent. No shared mission file was "
             "mutated because the v1 mission workspace writer is not implemented yet."
@@ -417,8 +375,8 @@ def _write_intent_validated_response(context: RuntimeRequestContext) -> RuntimeR
     return RuntimeResponse(
         response=write_result.summary,
         source=RUNTIME_RESPONSE_SOURCE,
-        session_id=context.session_id,
-        mission_id=context.mission_id,
+        session_id=payload.session_id,
+        mission_id=payload.mission_id,
         tool_calls=[],
         trajectory_artifact=None,
         write_result=write_result,
@@ -493,6 +451,7 @@ async def _run_chat_completion(
     *,
     payload: ChatRequest,
     request_started_at: float,
+    usage_source: str = "chat",
 ) -> ChatResponse:
     logger.info("Received chat message (%d chars)", len(payload.message))
 
@@ -585,6 +544,7 @@ async def _run_chat_completion(
                     llm_steps=llm_steps,
                     llm_usage=llm_usage,
                     request_started_at=request_started_at,
+                    usage_source=usage_source,
                 )
 
             # Append assistant tool-call message
@@ -630,6 +590,7 @@ async def _run_chat_completion(
                         llm_steps=llm_steps,
                         llm_usage=llm_usage,
                         request_started_at=request_started_at,
+                        usage_source=usage_source,
                     )
 
                 tool_key = (tool_name, json.dumps(tool_args, sort_keys=True))
@@ -722,6 +683,7 @@ async def _run_chat_completion(
             llm_steps=llm_steps,
             llm_usage=llm_usage,
             request_started_at=request_started_at,
+            usage_source=usage_source,
         )
 
     except Exception as e:
@@ -739,6 +701,7 @@ async def _run_chat_completion(
             llm_steps=llm_steps,
             llm_usage=llm_usage,
             request_started_at=request_started_at,
+            usage_source=usage_source,
         )
 
 
@@ -766,28 +729,28 @@ async def _run_chat_completion(
 async def runtime_request(request: Request) -> RuntimeResponse:
     request_started_at = time.perf_counter()
     payload = await _parse_runtime_request(request)
-    context = _build_runtime_context(payload)
 
     logger.info(
         "Received runtime request operation=%s mission_id=%s session_id=%s",
-        context.operation,
-        context.mission_id,
-        context.session_id,
+        payload.operation,
+        payload.mission_id,
+        payload.session_id,
     )
 
-    if context.operation == "write_intent":
-        return _write_intent_validated_response(context)
+    if payload.operation == "write_intent":
+        return _write_intent_validated_response(payload)
 
     chat_payload = ChatRequest(
-        message=context.message,
+        message=payload.message,
         history=[],
         enabled_tool_groups=payload.enabled_tool_groups,
     )
     chat_response = await _run_chat_completion(
         payload=chat_payload,
         request_started_at=request_started_at,
+        usage_source="runtime",
     )
     return _to_runtime_response(
-        context=context,
+        payload=payload,
         chat_response=chat_response,
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -185,7 +185,18 @@ def _validation_error_details(exc: ValidationError) -> list[dict]:
 
 
 async def _parse_raw_payload(request: Request, label: str) -> dict:
-    raw_body = await _read_limited_body(request)
+    try:
+        raw_body = await _read_limited_body(request)
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail={
+                    "error": f"{label} payload is too large.",
+                    "limit_bytes": CHAT_PAYLOAD_MAX_BYTES,
+                },
+            ) from exc
+        raise
 
     try:
         raw_payload = json.loads(raw_body)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,8 +29,13 @@ from app.schemas import (
     ChatRequest,
     ChatResponse,
     McpToolGroupId,
+    RuntimeRequest,
+    RuntimeRequestContext,
+    RuntimeResponse,
+    RuntimeSharedContext,
     TrajectoryArtifact,
     ToolCallRecord,
+    WriteResult,
 )
 
 
@@ -104,6 +109,7 @@ TOOL_CONTINUATION_RESPONSES = frozenset(
         "yep",
     }
 )
+RUNTIME_RESPONSE_SOURCE = "stratos-runtime-orchestrator"
 
 app.add_middleware(
     CORSMiddleware,
@@ -173,6 +179,13 @@ def _within_json_depth(value: object) -> bool:
     return True
 
 
+def _validation_error_details(exc: ValidationError) -> list[dict]:
+    try:
+        return exc.errors(include_context=False)
+    except TypeError:
+        return exc.errors()
+
+
 async def _parse_chat_request(request: Request) -> ChatRequest:
     raw_body = await _read_limited_body(request)
 
@@ -211,7 +224,50 @@ async def _parse_chat_request(request: Request) -> ChatRequest:
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "error": "Invalid chat request.",
-                "details": exc.errors(),
+                "details": _validation_error_details(exc),
+            },
+        ) from exc
+
+
+async def _parse_runtime_request(request: Request) -> RuntimeRequest:
+    raw_body = await _read_limited_body(request)
+
+    try:
+        raw_payload = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "Runtime request body must be valid JSON."},
+        ) from exc
+    except RecursionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "Runtime request JSON is too deeply nested."},
+        ) from exc
+
+    if not isinstance(raw_payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": "Runtime request body must be a JSON object."},
+        )
+
+    if not _within_json_depth(raw_payload):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "Runtime request JSON is too deeply nested.",
+                "limit_depth": CHAT_PAYLOAD_MAX_DEPTH,
+            },
+        )
+
+    try:
+        return RuntimeRequest.model_validate(raw_payload)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "Invalid runtime request.",
+                "details": _validation_error_details(exc),
             },
         ) from exc
 
@@ -317,6 +373,58 @@ def _record_latest_chat_usage(
     return response
 
 
+def _build_runtime_context(payload: RuntimeRequest) -> RuntimeRequestContext:
+    return RuntimeRequestContext(
+        user_id=payload.user_id,
+        mission_id=payload.mission_id,
+        session_id=payload.session_id,
+        operation=payload.operation,
+        message=payload.message,
+        write_intent=payload.write_intent,
+        shared_context=RuntimeSharedContext(),
+    )
+
+
+def _to_runtime_response(
+    *,
+    context: RuntimeRequestContext,
+    chat_response: ChatResponse,
+) -> RuntimeResponse:
+    return RuntimeResponse(
+        response=chat_response.response,
+        source=RUNTIME_RESPONSE_SOURCE,
+        session_id=context.session_id,
+        mission_id=context.mission_id,
+        tool_calls=chat_response.tool_calls,
+        trajectory_artifact=chat_response.trajectory_artifact,
+        write_result=None,
+    )
+
+
+def _write_intent_validated_response(context: RuntimeRequestContext) -> RuntimeResponse:
+    if context.write_intent is None:
+        raise ValueError("Runtime write intent context is missing write_intent.")
+
+    write_result = WriteResult(
+        operation=context.write_intent.operation,
+        target_file=context.write_intent.target_file,
+        summary=(
+            "Validated structured write intent. No shared mission file was "
+            "mutated because the v1 mission workspace writer is not implemented yet."
+        ),
+    )
+
+    return RuntimeResponse(
+        response=write_result.summary,
+        source=RUNTIME_RESPONSE_SOURCE,
+        session_id=context.session_id,
+        mission_id=context.mission_id,
+        tool_calls=[],
+        trajectory_artifact=None,
+        write_result=write_result,
+    )
+
+
 @app.post(
     "/chat",
     response_model=ChatResponse,
@@ -375,6 +483,17 @@ def _record_latest_chat_usage(
 async def chat(request: Request) -> ChatResponse:
     request_started_at = time.perf_counter()
     payload = await _parse_chat_request(request)
+    return await _run_chat_completion(
+        payload=payload,
+        request_started_at=request_started_at,
+    )
+
+
+async def _run_chat_completion(
+    *,
+    payload: ChatRequest,
+    request_started_at: float,
+) -> ChatResponse:
     logger.info("Received chat message (%d chars)", len(payload.message))
 
     tool_calls_log: list[ToolCallRecord] = []
@@ -621,3 +740,54 @@ async def chat(request: Request) -> ChatResponse:
             llm_usage=llm_usage,
             request_started_at=request_started_at,
         )
+
+
+@app.post(
+    "/runtime/request",
+    response_model=RuntimeResponse,
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "example": {
+                        "user_id": "u_123",
+                        "mission_id": "aero",
+                        "session_id": "sess_abc123",
+                        "operation": "chat",
+                        "message": "What are the current pre-flight blockers?",
+                        "write_intent": None,
+                    }
+                }
+            },
+        }
+    },
+)
+async def runtime_request(request: Request) -> RuntimeResponse:
+    request_started_at = time.perf_counter()
+    payload = await _parse_runtime_request(request)
+    context = _build_runtime_context(payload)
+
+    logger.info(
+        "Received runtime request operation=%s mission_id=%s session_id=%s",
+        context.operation,
+        context.mission_id,
+        context.session_id,
+    )
+
+    if context.operation == "write_intent":
+        return _write_intent_validated_response(context)
+
+    chat_payload = ChatRequest(
+        message=context.message,
+        history=[],
+        enabled_tool_groups=payload.enabled_tool_groups,
+    )
+    chat_response = await _run_chat_completion(
+        payload=chat_payload,
+        request_started_at=request_started_at,
+    )
+    return _to_runtime_response(
+        context=context,
+        chat_response=chat_response,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,11 +10,13 @@ from fastapi import FastAPI, HTTPException, Request, status
 
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.auth import get_current_user_id
 from app.prompt_assembly import (
     format_client_history_message,
     format_current_user_message,
     format_tool_output_message,
 )
+from app.supabase_client import get_supabase
 from app.usage_log import write_latest_chat_usage
 from llm import OpenAIProvider, execute_tool
 from app.config import get_settings
@@ -35,6 +37,7 @@ from app.schemas import (
     ToolCallRecord,
     WriteResult,
 )
+from fastapi import Depends
 
 
 settings = get_settings()
@@ -116,7 +119,7 @@ app.add_middleware(
         "http://127.0.0.1:3000",
     ],
     allow_methods=["POST", "GET", "OPTIONS"],
-    allow_headers=["Content-Type"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 
@@ -355,6 +358,67 @@ def _record_latest_chat_usage(
         }
     )
     return response
+
+
+def _upsert_session(user_id: str, session_id: str, mission_id: str) -> None:
+    try:
+        get_supabase().table("user_sessions").upsert(
+            {
+                "id": session_id,
+                "user_id": user_id,
+                "mission_id": mission_id,
+                "last_active_at": "now()",
+            },
+            on_conflict="id",
+        ).execute()
+    except Exception:
+        logger.warning("Failed to upsert user session %s", session_id, exc_info=True)
+
+
+def _load_history(session_id: str) -> list[dict]:
+    try:
+        result = (
+            get_supabase()
+            .table("messages")
+            .select("role,content")
+            .eq("session_id", session_id)
+            .order("created_at")
+            .limit(CHAT_HISTORY_MAX_ITEMS)
+            .execute()
+        )
+        return result.data or []
+    except Exception:
+        logger.warning("Failed to load history for session %s", session_id, exc_info=True)
+        return []
+
+
+def _save_messages(
+    *,
+    session_id: str,
+    user_id: str,
+    mission_id: str,
+    user_content: str,
+    assistant_content: str,
+) -> None:
+    try:
+        get_supabase().table("messages").insert([
+            {
+                "session_id": session_id,
+                "user_id": user_id,
+                "mission_id": mission_id,
+                "role": "user",
+                "content": user_content,
+            },
+            {
+                "session_id": session_id,
+                "user_id": user_id,
+                "mission_id": mission_id,
+                "role": "assistant",
+                "content": assistant_content,
+            },
+        ]).execute()
+    except Exception:
+        logger.warning("Failed to save messages for session %s", session_id, exc_info=True)
 
 
 def _to_runtime_response(
@@ -737,23 +801,35 @@ async def _run_chat_completion(
         }
     },
 )
-async def runtime_request(request: Request) -> RuntimeResponse:
+async def runtime_request(
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+) -> RuntimeResponse:
     request_started_at = time.perf_counter()
     payload = await _parse_runtime_request(request)
 
     logger.info(
-        "Received runtime request operation=%s mission_id=%s session_id=%s",
+        "Received runtime request operation=%s mission_id=%s session_id=%s user_id=%s",
         payload.operation,
         payload.mission_id,
         payload.session_id,
+        user_id,
     )
+
+    _upsert_session(user_id, payload.session_id, payload.mission_id)
 
     if payload.operation == "write_intent":
         return _write_intent_validated_response(payload)
 
+    db_history = _load_history(payload.session_id)
+    chat_history = [
+        ChatHistoryMessage(role=m["role"], content=m["content"])
+        for m in db_history
+    ]
+
     chat_payload = ChatRequest(
         message=payload.message,
-        history=[],
+        history=chat_history,
         enabled_tool_groups=payload.enabled_tool_groups,
     )
     chat_response = await _run_chat_completion(
@@ -761,6 +837,15 @@ async def runtime_request(request: Request) -> RuntimeResponse:
         request_started_at=request_started_at,
         usage_source="runtime",
     )
+
+    _save_messages(
+        session_id=payload.session_id,
+        user_id=user_id,
+        mission_id=payload.mission_id,
+        user_content=payload.message,
+        assistant_content=chat_response.response,
+    )
+
     return _to_runtime_response(
         payload=payload,
         chat_response=chat_response,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -62,6 +62,8 @@ class WriteIntent(BaseModel):
         if value is None:
             return None
 
+        if "\x00" in value:
+            raise ValueError("Field must not contain null bytes.")
         stripped = value.strip()
         if not stripped:
             raise ValueError("Field must not be blank.")
@@ -122,23 +124,6 @@ class TrustedConversationState(BaseModel):
     """Server-owned prior tool activity reconstructed from observed execution."""
 
     tool_calls: list[ToolCallRecord] = Field(default_factory=list)
-
-
-class RuntimeSharedContext(BaseModel):
-    """Server-owned mission context envelope placeholder for runtime calls."""
-
-    core_documents: list[str] = Field(default_factory=list)
-    intent_documents: list[str] = Field(default_factory=list)
-
-
-class RuntimeRequestContext(BaseModel):
-    user_id: str
-    mission_id: str
-    session_id: str
-    operation: RuntimeOperation
-    message: str
-    write_intent: WriteIntent | None = None
-    shared_context: RuntimeSharedContext = Field(default_factory=RuntimeSharedContext)
 
 
 class TrajectoryArtifactPoint(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from pathlib import PurePosixPath
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 McpToolGroupId = Literal["trajectory", "weather", "airspace"]
+RuntimeOperation = Literal["chat", "write_intent"]
+WriteIntentOperation = Literal[
+    "checklist_item_set_status",
+    "append_planning_note",
+    "append_decision_entry",
+    "update_status_summary",
+]
 
 CHAT_MESSAGE_MAX_CHARS = 8_000
 CHAT_HISTORY_MESSAGE_MAX_CHARS = 8_000
@@ -37,10 +45,100 @@ class ChatRequest(BaseModel):
     enabled_tool_groups: list[McpToolGroupId] | None = None
 
 
+class WriteIntent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operation: WriteIntentOperation
+    target_file: str = Field(min_length=1)
+    mission_id: str | None = None
+    item_id: str | None = None
+    new_status: str | None = None
+    entry: dict[str, Any] | None = None
+    summary: str | None = None
+
+    @field_validator("mission_id", "target_file", "item_id", "new_status", "summary")
+    @classmethod
+    def _strip_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Field must not be blank.")
+        return stripped
+
+
+class RuntimeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str = Field(min_length=1)
+    mission_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    operation: RuntimeOperation
+    message: str = Field(max_length=CHAT_MESSAGE_MAX_CHARS)
+    write_intent: WriteIntent | None = None
+    enabled_tool_groups: list[McpToolGroupId] | None = None
+
+    @field_validator("user_id", "mission_id", "session_id", "message")
+    @classmethod
+    def _strip_required_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Field must not be blank.")
+        return stripped
+
+    @model_validator(mode="after")
+    def _validate_operation_contract(self) -> "RuntimeRequest":
+        if self.operation == "chat" and self.write_intent is not None:
+            raise ValueError("Chat requests must not include write_intent.")
+
+        if self.operation == "write_intent" and self.write_intent is None:
+            raise ValueError("write_intent operation requires write_intent.")
+
+        if self.write_intent is not None:
+            if (
+                self.write_intent.mission_id is not None
+                and self.write_intent.mission_id != self.mission_id
+            ):
+                raise ValueError("write_intent.mission_id must match mission_id.")
+
+            target_path = PurePosixPath(self.write_intent.target_file)
+            if target_path.is_absolute() or ".." in target_path.parts:
+                raise ValueError("write_intent.target_file must stay inside mission files.")
+
+            if (
+                len(target_path.parts) < 3
+                or target_path.parts[0] != "missions"
+                or target_path.parts[1] != self.mission_id
+            ):
+                raise ValueError(
+                    "write_intent.target_file must be under missions/{mission_id}/."
+                )
+
+        return self
+
+
 class TrustedConversationState(BaseModel):
     """Server-owned prior tool activity reconstructed from observed execution."""
 
     tool_calls: list[ToolCallRecord] = Field(default_factory=list)
+
+
+class RuntimeSharedContext(BaseModel):
+    """Server-owned mission context envelope placeholder for runtime calls."""
+
+    core_documents: list[str] = Field(default_factory=list)
+    intent_documents: list[str] = Field(default_factory=list)
+
+
+class RuntimeRequestContext(BaseModel):
+    user_id: str
+    mission_id: str
+    session_id: str
+    operation: RuntimeOperation
+    message: str
+    write_intent: WriteIntent | None = None
+    shared_context: RuntimeSharedContext = Field(default_factory=RuntimeSharedContext)
 
 
 class TrajectoryArtifactPoint(BaseModel):
@@ -85,3 +183,20 @@ class ChatResponse(BaseModel):
     source: str
     tool_calls: list[ToolCallRecord] = Field(default_factory=list)
     trajectory_artifact: TrajectoryArtifact | None = None
+
+
+class WriteResult(BaseModel):
+    status: Literal["validated"] = "validated"
+    operation: WriteIntentOperation
+    target_file: str
+    summary: str
+
+
+class RuntimeResponse(BaseModel):
+    response: str
+    source: str
+    session_id: str
+    mission_id: str
+    tool_calls: list[ToolCallRecord] = Field(default_factory=list)
+    trajectory_artifact: TrajectoryArtifact | None = None
+    write_result: WriteResult | None = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -84,6 +84,8 @@ class RuntimeRequest(BaseModel):
     @field_validator("user_id", "mission_id", "session_id", "message")
     @classmethod
     def _strip_required_text(cls, value: str) -> str:
+        if "\x00" in value:
+            raise ValueError("Field must not contain null bytes.")
         stripped = value.strip()
         if not stripped:
             raise ValueError("Field must not be blank.")

--- a/backend/app/supabase_client.py
+++ b/backend/app/supabase_client.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from supabase import Client, create_client
+
+from app.config import get_settings
+
+
+@lru_cache(maxsize=1)
+def get_supabase() -> Client:
+    settings = get_settings()
+    if not settings.supabase_url or not settings.supabase_service_key:
+        raise RuntimeError(
+            "SUPABASE_URL and SUPABASE_SERVICE_KEY must be set to use the Supabase client."
+        )
+    return create_client(settings.supabase_url, settings.supabase_service_key)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ httpx
 pydantic
 fastmcp
 mcp
+supabase>=2.15.0,<3.0.0
 Flask>=3.0.0,<4.0.0
 deap>=1.4.4,<2.0.0
 Flask>=3.1.3,<4.0.0

--- a/backend/tests/test_runtime_contract.py
+++ b/backend/tests/test_runtime_contract.py
@@ -5,12 +5,21 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from app.auth import get_current_user_id
 from app.main import app
 from app.schemas import CHAT_PAYLOAD_MAX_BYTES, CHAT_PAYLOAD_MAX_DEPTH
+
+
+@pytest.fixture(autouse=True)
+def authenticated_user():
+    app.dependency_overrides[get_current_user_id] = lambda: "u_123"
+    yield
+    app.dependency_overrides.pop(get_current_user_id, None)
 
 
 def make_message(content: str) -> SimpleNamespace:

--- a/backend/tests/test_runtime_contract.py
+++ b/backend/tests/test_runtime_contract.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.main import app
+from app.schemas import CHAT_PAYLOAD_MAX_BYTES, CHAT_PAYLOAD_MAX_DEPTH
+
+
+def make_message(content: str) -> SimpleNamespace:
+    return SimpleNamespace(content=content, tool_calls=None)
+
+
+class FakeCompletions:
+    def __init__(self, responses: list[SimpleNamespace] | None = None) -> None:
+        self.last_kwargs: dict | None = None
+        self.calls: list[dict] = []
+        self.responses = responses or [make_message("Runtime chat response.")]
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        self.last_kwargs = kwargs
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=self.responses.pop(0))],
+            usage=None,
+        )
+
+
+class FakeProvider:
+    completions = FakeCompletions()
+
+    def __init__(self) -> None:
+        self._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=self.completions),
+        )
+
+    def get_client(self):
+        return self._client
+
+    def get_model(self) -> str:
+        return "test-model"
+
+    def get_tools(self, enabled_tool_groups=None):
+        from llm import get_tools
+
+        return get_tools(enabled_tool_groups)
+
+    def get_system_prompt(self) -> str:
+        return "Test prompt"
+
+
+def runtime_chat_payload(**overrides):
+    payload = {
+        "user_id": "u_123",
+        "mission_id": "aero",
+        "session_id": "sess_abc123",
+        "operation": "chat",
+        "message": "Summarize the current weather concerns.",
+        "write_intent": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_runtime_chat_returns_mission_runtime_metadata(monkeypatch) -> None:
+    FakeProvider.completions = FakeCompletions()
+    monkeypatch.setattr("app.main.OpenAIProvider", FakeProvider)
+
+    response = TestClient(app).post(
+        "/runtime/request",
+        json=runtime_chat_payload(enabled_tool_groups=["weather"]),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "response": "Runtime chat response.",
+        "source": "stratos-runtime-orchestrator",
+        "session_id": "sess_abc123",
+        "mission_id": "aero",
+        "tool_calls": [],
+        "trajectory_artifact": None,
+        "write_result": None,
+    }
+    assert FakeProvider.completions.last_kwargs is not None
+    assert FakeProvider.completions.last_kwargs["messages"] == [
+        {"role": "system", "content": "Test prompt"},
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "content": "Summarize the current weather concerns.",
+                    "kind": "user_input",
+                    "source": "current_user",
+                    "trust": "untrusted",
+                }
+            ),
+        },
+    ]
+    tool_names = [
+        tool["function"]["name"]
+        for tool in FakeProvider.completions.last_kwargs["tools"]
+    ]
+    assert tool_names == ["get_surface_weather", "get_winds_aloft"]
+
+
+def test_runtime_request_rejects_missing_identity_fields() -> None:
+    for field in ("user_id", "mission_id", "session_id", "operation", "message"):
+        payload = runtime_chat_payload()
+        payload.pop(field)
+
+        response = TestClient(app).post("/runtime/request", json=payload)
+
+        assert response.status_code == 422
+        assert response.json()["detail"]["error"] == "Invalid runtime request."
+
+
+def test_runtime_request_rejects_invalid_operation() -> None:
+    response = TestClient(app).post(
+        "/runtime/request",
+        json=runtime_chat_payload(operation="delete_mission"),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "Invalid runtime request."
+
+
+def test_runtime_chat_rejects_client_history() -> None:
+    response = TestClient(app).post(
+        "/runtime/request",
+        json=runtime_chat_payload(
+            history=[{"role": "user", "content": "trusted mission state"}],
+        ),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "Invalid runtime request."
+
+
+def test_runtime_write_intent_validates_without_mutating() -> None:
+    response = TestClient(app).post(
+        "/runtime/request",
+        json={
+            "user_id": "u_123",
+            "mission_id": "aero",
+            "session_id": "sess_abc123",
+            "operation": "write_intent",
+            "message": "Mark payload power verification complete.",
+            "write_intent": {
+                "operation": "checklist_item_set_status",
+                "mission_id": "aero",
+                "target_file": "missions/aero/checklists/preflight.md",
+                "item_id": "payload-power-verification",
+                "new_status": "done",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source"] == "stratos-runtime-orchestrator"
+    assert body["session_id"] == "sess_abc123"
+    assert body["mission_id"] == "aero"
+    assert body["tool_calls"] == []
+    assert body["trajectory_artifact"] is None
+    assert body["write_result"] == {
+        "status": "validated",
+        "operation": "checklist_item_set_status",
+        "target_file": "missions/aero/checklists/preflight.md",
+        "summary": (
+            "Validated structured write intent. No shared mission file was "
+            "mutated because the v1 mission workspace writer is not implemented yet."
+        ),
+    }
+
+
+def test_runtime_write_intent_rejects_invalid_operation() -> None:
+    payload = {
+        "user_id": "u_123",
+        "mission_id": "aero",
+        "session_id": "sess_abc123",
+        "operation": "write_intent",
+        "message": "Rewrite the whole mission.",
+        "write_intent": {
+            "operation": "rewrite_mission",
+            "target_file": "missions/aero/mission.md",
+        },
+    }
+
+    response = TestClient(app).post("/runtime/request", json=payload)
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "Invalid runtime request."
+
+
+def test_runtime_write_intent_rejects_cross_mission_and_traversal_paths() -> None:
+    invalid_intents = [
+        {
+            "operation": "append_planning_note",
+            "mission_id": "other",
+            "target_file": "missions/aero/planning/weather-notes.md",
+        },
+        {
+            "operation": "append_planning_note",
+            "target_file": "missions/other/planning/weather-notes.md",
+        },
+        {
+            "operation": "append_planning_note",
+            "target_file": "missions/aero/../other/notes.md",
+        },
+        {
+            "operation": "append_planning_note",
+            "target_file": "/missions/aero/planning/weather-notes.md",
+        },
+    ]
+
+    for write_intent in invalid_intents:
+        response = TestClient(app).post(
+            "/runtime/request",
+            json={
+                "user_id": "u_123",
+                "mission_id": "aero",
+                "session_id": "sess_abc123",
+                "operation": "write_intent",
+                "message": "Add a note.",
+                "write_intent": write_intent,
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"]["error"] == "Invalid runtime request."
+
+
+def test_runtime_request_reuses_serialized_payload_limit() -> None:
+    body = json.dumps(runtime_chat_payload(message="x" * CHAT_PAYLOAD_MAX_BYTES))
+
+    response = TestClient(app).post(
+        "/runtime/request",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+
+
+def test_runtime_request_reuses_json_depth_limit() -> None:
+    nested = "x"
+    for _ in range(CHAT_PAYLOAD_MAX_DEPTH + 1):
+        nested = [nested]
+
+    response = TestClient(app).post(
+        "/runtime/request",
+        json=runtime_chat_payload(metadata=nested),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "Runtime request JSON is too deeply nested."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      APP_ENV: production
+      LOG_LEVEL: INFO
+      HOST: 0.0.0.0
+      PORT: "8000"
+      LLM_API_KEY: "${LLM_API_KEY}"
+      LLM_MODEL: "${LLM_MODEL:-gpt-4o-mini}"
+      FAA_CLIENT_ID: "${FAA_CLIENT_ID}"
+      FAA_CLIENT_SECRET: "${FAA_CLIENT_SECRET}"
+      LAMINAR_USER_KEY: "${LAMINAR_USER_KEY}"
+      SUPABASE_URL: "${SUPABASE_URL}"
+      SUPABASE_SERVICE_KEY: "${SUPABASE_SERVICE_KEY}"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_SUPABASE_URL: "${NEXT_PUBLIC_SUPABASE_URL}"
+        NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "${NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY}"
+        NEXT_PUBLIC_BACKEND_URL: ""
+    restart: unless-stopped
+    environment:
+      BACKEND_URL: "http://backend:8000"
+    ports:
+      - "3000:3000"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/', r => process.exit(r.statusCode < 500 ? 0 : 1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/docs/stratos-chat-continuation-roadmap.md
+++ b/docs/stratos-chat-continuation-roadmap.md
@@ -1,0 +1,314 @@
+# Stratos Chat Continuation Roadmap
+
+Date: 2026-05-15
+
+## Executive Recommendation
+
+Do not start with a full OpenAI Agents SDK rewrite. The best tradeoff for Stratos is a staged path:
+
+1. Add server-owned Stratos conversation state first, modeled as a runtime-neutral event ledger.
+2. Add context assembly, rolling summaries, trusted tool-result summaries, and persisted chat UI/search.
+3. Migrate the model primitive from Chat Completions to Responses API when state assembly is testable.
+4. Pilot the OpenAI Agents SDK only after Stratos has durable sessions, evals, and clear tool-continuity rules.
+
+This gets the biggest user-visible win quickly: chats can continue after the frontend session or prompt window is too large. It also avoids throwing away the current safety work around untrusted client history before there is a replacement state model. The key architectural guardrail is that local Stratos events remain authoritative while OpenAI runtime IDs, traces, conversations, and SDK sessions are linked projections.
+
+## Current Stratos Architecture
+
+Stratos currently uses a manual chat runtime:
+
+- The frontend stores messages in React state in `frontend/src/app/chat/page.tsx` and sends prior messages to the backend on each turn.
+- `frontend/src/lib/chatApi.ts` serializes `message` plus mapped `history`.
+- `backend/app/schemas.py` caps history to 30 items, with 8,000 characters per message and 512 KiB per request body.
+- `backend/app/main.py` constructs a Chat Completions message list, injects sanitized client history, calls `client.chat.completions.create(...)`, then manually loops over tool calls.
+- `backend/llm.py` owns OpenAI tool schemas, the STRATOS system prompt, and direct dispatch to weather, airspace, and SondeHub tools.
+- `README.md` explicitly says client-supplied history is untrusted and that future trusted tool continuity must come from server-owned state.
+
+That design is healthy for the current scale. It is intentionally defensive. The context-limit problem appears because the only conversation memory is client replay plus recent request payloads. Once the conversation grows, Stratos either sends too much, truncates too much, or loses details.
+
+## What The Agents SDK Would Change
+
+OpenAI describes the Agents SDK as the right path when the application owns orchestration, tool execution, approvals, and state. It supports code-first agents, tool use, handoffs, streaming, sessions, and tracing. Official docs also show four continuation strategies: app-owned history, SDK session, OpenAI Conversation ID, or `previous_response_id`.
+
+Changing Stratos to the Agents SDK would require:
+
+- Add `openai-agents` to backend dependencies.
+- Create a STRATOS mission agent with the current system prompt from `backend/llm.py`.
+- Convert the current tool schemas into SDK function tools or connect the existing MCP servers through SDK-managed MCP.
+- Replace the manual loop in `backend/app/main.py` with `Runner.run(...)` / `Runner.run_streamed(...)`.
+- Persist a session or continuation key per Stratos conversation.
+- Extract tool-call records, final output, usage, trace IDs, and trajectory artifacts from SDK run results.
+- Preserve current prompt-injection boundaries: client history, retrieved docs, and tool outputs must remain untrusted unless created by server state.
+- Add tests around SDK tool routing, duplicate tool prevention, timeouts, and server-owned tool history.
+
+## Benefits Over Current Setup
+
+The SDK would give Stratos:
+
+- A maintained runner loop instead of hand-written model/tool iteration.
+- Built-in continuation surfaces: `history`, sessions, Conversation IDs, and `previous_response_id`.
+- Handoffs for future specialists such as Weather Analyst, Trajectory Analyst, Airspace Reviewer, and Mission Checklist Agent.
+- Tracing for model calls, tool calls, handoffs, guardrails, and custom spans.
+- Streaming and resumable state for interrupted or approval-gated runs.
+- Cleaner integration with SDK-managed MCP if Stratos expands its tool system.
+
+The SDK does not automatically solve all context problems:
+
+- Context windows still apply.
+- OpenAI docs say previous inputs in a chained `previous_response_id` conversation are still billed as input tokens.
+- If Stratos uses OpenAI Conversations, those items may persist without the same 30-day response TTL, so data governance must be a conscious decision.
+- Stratos still needs local search, UI history, mission scoping, audit records, and trusted tool ledgers.
+
+## OpenAI API/SDK Findings
+
+Official documentation says Responses is the recommended API primitive for new projects and supports stateful, tool-using interactions. It also notes that Chat Completions remains supported, but conversation state is managed manually there.
+
+Useful continuation mechanisms:
+
+- Responses with `previous_response_id`: lightest server-managed continuation, but still bills previous input tokens.
+- Conversations API: durable server-managed conversation object that stores messages, tool calls, tool outputs, and other items.
+- Responses `context_management`: can trigger compaction at a token threshold.
+- `/responses/compact`: returns compacted items, including opaque encrypted compaction content.
+- Agents SDK sessions: app-controlled persistent chat state and resumable runs.
+- Agents SDK tracing: structured visibility into model calls, tool calls, handoffs, guardrails, and custom spans.
+
+Important cost notes:
+
+- As of the current OpenAI pricing page, `gpt-5.5` standard pricing is listed at $5 input / $0.50 cached input / $30 output per 1M short-context tokens, while `gpt-5.4-mini` is much cheaper at $0.75 input / $0.075 cached input / $4.50 output per 1M tokens.
+- OpenAI cost guidance recommends reducing requests, minimizing tokens, and selecting smaller models where quality remains acceptable.
+- For Stratos, the biggest cost lever is not only model choice; it is reducing repeated history, summarizing large tool outputs, and keeping full artifacts out of the model prompt.
+
+## Staged Roadmap
+
+### Stage 0: Baseline And Token Budget
+
+Effort: 0.5-1 day.
+
+Add durable metrics before changing runtime:
+
+- Prompt/input token estimate per turn.
+- Number of history messages sent.
+- Tool schema payload size.
+- Tool result payload size.
+- Model latency and total request latency.
+- Tool-call count and selected tool group.
+- Whether a trajectory artifact was produced.
+
+Why first: Stratos already optimized normal chat by routing tool schemas only when needed. Keep that discipline and make future changes measurable.
+
+### Stage 1: Server-Owned Conversation Store
+
+Effort: 3-5 days for an MVP.
+
+Add backend-owned persistence as an append-only event ledger plus read models:
+
+- Conversation read model: id, mission_id, title, created_at, updated_at.
+- Message read model: conversation_id, role, content, created_at, source/trust metadata.
+- Trusted tool-call read model: server-observed calls with args, status, latency, and result reference.
+- Tool result summaries: compact model-facing summaries.
+- Memory snapshots: rolling mission summary, pinned facts, decisions, unresolved questions.
+- Event ledger: `user_message_received`, `assistant_message_created`, `model_tool_call_requested`, `tool_call_started`, `tool_call_completed`, `tool_call_failed`, `artifact_created`, `summary_created`, `fact_pinned`, `fact_retracted`, and `runtime_trace_linked`.
+
+Change `/chat` to accept `conversation_id` plus the current message. Keep `history` temporarily for compatibility, but stop relying on it as the primary source of truth.
+
+Also add turn ordering and retry safety:
+
+- `turn_id`.
+- `client_request_id`.
+- Append sequence.
+- Idempotency key for tool jobs.
+- Stale conversation handling.
+- Duplicate-send and reload behavior.
+
+Frontend changes:
+
+- Sidebar shows persisted chats instead of "No chats".
+- New chat creates a server conversation.
+- Search uses persisted messages/summaries.
+- Reloading the page restores the conversation.
+
+This stage solves the immediate user problem without changing the model API.
+
+Important split: persisted transcript, audit ledger, model context, search index, and pinned mission facts should be separate projections. A saved assistant message is not automatically safe or useful memory for the next model call.
+
+### Stage 2: Context Assembly And Memory Policy
+
+Effort: 4-7 days.
+
+Create a deterministic context builder:
+
+- Recent N messages.
+- Rolling mission summary.
+- Pinned operational facts.
+- Active mission configuration.
+- Trusted tool-call summaries.
+- Retrieved mission docs using the existing untrusted envelope style.
+- Current user message.
+
+Add a token budget:
+
+- Reserve output tokens.
+- Reserve tool schema/tool result space.
+- Drop oldest raw turns first.
+- Keep pinned facts and structured mission data ahead of prose.
+
+Key optimization: do not send full trajectory artifacts to the model when a compact summary will do. Keep the full artifact for the UI map and audit trail.
+
+Make summaries derived and disposable:
+
+- Store summary source event range.
+- Store summary policy version.
+- Store model/runtime used to create it.
+- Store token budget assumptions.
+- Regenerate summaries when facts are retracted or tool outputs are superseded.
+- Never make a prose summary the only home of mission-critical facts.
+
+Trust labels should exist below the message level, not only around entire messages. Useful classes include `client_claim`, `server_observed_tool_result`, `derived_summary`, `operator_pinned`, and `retrieved_document`.
+
+### Stage 3: Responses API Migration
+
+Effort: 5-10 days.
+
+Build a provider adapter next to the current `OpenAIProvider`:
+
+- Convert `messages` to Responses `input` and `instructions`.
+- Port function-call handling from Chat Completions to Responses item handling.
+- Keep the current provider behind a feature flag.
+- Test `previous_response_id`, Conversations API, and compaction against Stratos' local store.
+
+Recommendation: keep Stratos' local store authoritative even when using OpenAI-managed state. Use OpenAI state as a runtime accelerator, not as the only mission record.
+
+The migration spike should answer more than "can the API call work?" It should produce a compatibility matrix for:
+
+- Tool-call representation.
+- Retry and idempotency behavior.
+- Trace/run linkage.
+- Compaction semantics.
+- Cost accounting.
+- Failure recovery.
+- How to reconstruct the Stratos event ledger from runtime outputs.
+
+### Stage 4: Compaction And Retrieval
+
+Effort: 3-7 days after Stage 3.
+
+Add two kinds of compression:
+
+- Human-readable Stratos summaries for UI/search/audit.
+- Model-facing compaction for long-running Responses workflows.
+
+Add retrieval:
+
+- Search prior conversation decisions and mission facts.
+- Retrieve mission documents with the existing untrusted-context envelope.
+- Optionally add embeddings/vector search later, once basic persistence and keyword search prove useful.
+
+### Stage 5: Agents SDK Pilot
+
+Effort: 1-2 weeks for a serious pilot.
+
+Start with one agent, not a multi-agent redesign:
+
+- STRATOS Mission Copilot agent.
+- Existing weather, airspace, and trajectory tools wrapped as SDK function tools.
+- Session mapped to local `conversation_id`.
+- Trace ID recorded with each run.
+- Streaming enabled only after non-streaming parity is solid.
+
+Then test specialists:
+
+- Weather Analyst.
+- Trajectory Analyst.
+- Airspace Reviewer.
+- Mission Readiness Reviewer.
+
+Only keep specialists if evals show better tool selection, safer recommendations, or clearer mission output.
+
+Out of scope for the MVP: shipping multi-agent specialists during Stage 1 or Stage 2. The first implementation should prove durable conversations, context assembly, and trusted tool summaries before adding specialist handoffs.
+
+## Recommended Architecture
+
+Use three layers:
+
+1. Local Stratos state layer:
+   - Source of truth for conversations, messages, trusted tool calls, summaries, mission facts, and UI search.
+
+2. Model runtime adapter:
+   - Starts as current Chat Completions provider.
+   - Evolves into Responses provider.
+   - Later can run Agents SDK behind the same app-level contract.
+
+3. Context policy layer:
+   - Owns what goes into the model prompt.
+   - Enforces token budget.
+   - Keeps untrusted data wrapped.
+   - Summarizes heavy tool outputs.
+
+This separation is the main reason not to jump directly to Agents SDK. If Stratos first defines its own conversation contract, each runtime becomes a replaceable implementation detail.
+
+The local contract should be event-first. That avoids three competing state machines later: a Stratos ledger, a Responses conversation, and an Agents SDK session. Stratos owns the mission record; the runtime adapter stores upstream IDs and trace references as links.
+
+## Other Project Optimizations
+
+High-impact backend optimizations:
+
+- Summarize tool outputs before adding them to model context.
+- Store full map/trajectory artifacts outside the prompt.
+- Add async/background job handling for long SondeHub/no-flight-zone runs instead of holding one request for up to 120 seconds.
+- Add token counting in tests for representative prompts.
+- Add model routing: cheaper model for casual chat, stronger model for launch recommendation or multi-tool risk analysis.
+- Add eval fixtures for tool selection and GO/CAUTION/NO-GO output.
+- Keep intent routing, but make tool-group selection observable and overrideable.
+
+Frontend optimizations:
+
+- Replace placeholder chat history with persisted conversations.
+- Make search real once messages are stored.
+- Show accurate loading states instead of always cycling through weather/simulation messages.
+- Add a "context carried forward" indicator when old turns are summarized.
+- Show tool result cards from trusted server records, not client-supplied history.
+
+Safety and reliability optimizations:
+
+- Keep the current untrusted envelope pattern.
+- Add tests for prompt injection inside retrieved summaries.
+- Add structured mission fact extraction with source references.
+- Keep manual restriction/TFR review language pinned in memory and tested.
+- Add audit export for a mission conversation.
+- Promote long SondeHub/no-flight-zone work into resumable tool jobs with status records and artifact references.
+- Add idempotency tests for duplicate sends, retries, and reloads.
+- Ensure "restriction lookup unavailable" and similar uncertainty survives summarization with the same operational force as the original tool result.
+- Add a token-budget fixture with 100 prior turns plus a large trajectory artifact; the model-facing prompt must stay under the configured budget while the full artifact remains available to the UI/audit trail.
+- Add summary-regeneration tests for `fact_retracted` and superseded tool-output events.
+
+## Decision Matrix
+
+| Path | Continuity value | Migration risk | Cost control | UI/search value | Long-term agent fit |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Current client replay only | Low | Low | Low | Low | Low |
+| Local store + summaries | High | Low-Medium | High | High | Medium |
+| Responses + local store | High | Medium | High | Medium | High |
+| Agents SDK immediately | Medium | High | Medium | Low initially | High |
+| Staged hybrid | High | Medium | High | High | High |
+
+## Final Recommendation
+
+Build the local conversation/memory layer first, then migrate to Responses, then pilot Agents SDK. The local layer is not wasted work; it is the product contract Stratos needs no matter which OpenAI runtime wins.
+
+Architect-review refinement: make that local layer an append-only, trust-labeled event ledger with separate projections for transcript, audit, model memory, summaries, search, and mission facts. That turns "local memory" from temporary glue into the stable architecture that makes later Responses and Agents SDK adoption safer.
+
+## Sources
+
+- OpenAI, [Agents SDK overview](https://developers.openai.com/api/docs/guides/agents)
+- OpenAI, [Agents SDK quickstart](https://developers.openai.com/api/docs/guides/agents/quickstart)
+- OpenAI, [Running agents](https://developers.openai.com/api/docs/guides/agents/running-agents)
+- OpenAI, [Agents results and state](https://developers.openai.com/api/docs/guides/agents/results)
+- OpenAI, [Agents integrations and observability](https://developers.openai.com/api/docs/guides/agents/integrations-observability)
+- OpenAI, [Migrate to Responses](https://developers.openai.com/api/docs/guides/migrate-to-responses)
+- OpenAI, [Conversation state](https://developers.openai.com/api/docs/guides/conversation-state)
+- OpenAI, [Responses create API reference](https://developers.openai.com/api/reference/resources/responses/methods/create)
+- OpenAI, [Responses compact API reference](https://developers.openai.com/api/reference/resources/responses/methods/compact)
+- OpenAI, [Models](https://developers.openai.com/api/docs/models)
+- OpenAI, [Pricing](https://developers.openai.com/api/docs/pricing)
+- OpenAI, [Cost optimization](https://developers.openai.com/api/docs/guides/cost-optimization)
+- OpenAI, [Counting tokens](https://developers.openai.com/api/docs/guides/token-counting)

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+.env
+.env.*
+*.tsbuildinfo

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,7 @@ BACKEND_URL="http://localhost:8000"
 # Optional: bypass the Next.js proxy and call the backend directly from the browser.
 # Recommended for local development if `/api/chat` logs intermittent socket hang ups.
 NEXT_PUBLIC_BACKEND_URL="http://127.0.0.1:8000"
+
+# Supabase (managed backend)
+NEXT_PUBLIC_SUPABASE_URL="https://bhxkhpszeeblchomppse.supabase.co"
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="sb_publishable_mGJhQe7MIOWuTnnMonlfVQ_j3bDZZci"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# Build args for public env vars baked into the static bundle
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_BACKEND_URL
+
+RUN npm run build
+
+# ─────────────────────────────────────────────
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3000/', r => process.exit(r.statusCode < 500 ? 0 : 1))"
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   async rewrites() {
     return [
       {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "stratos-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.12.0",
+        "@supabase/supabase-js": "^2.108.1",
         "leaflet": "^1.9.4",
         "next": "16.2.6",
         "react": "^19.2.5",
@@ -57,7 +59,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1324,6 +1325,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.0.tgz",
+      "integrity": "sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.108.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1438,7 +1535,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1504,7 +1600,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1984,7 +2079,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2343,7 +2437,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2554,6 +2647,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2990,7 +3096,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3971,6 +4076,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4649,8 +4763,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6144,7 +6257,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6154,7 +6266,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6974,7 +7085,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7157,7 +7267,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7548,7 +7657,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@supabase/ssr": "^0.12.0",
+    "@supabase/supabase-js": "^2.108.1",
     "leaflet": "^1.9.4",
     "next": "16.2.6",
     "react": "^19.2.5",

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
-import type { Message } from "@/types/chat";
+import { useRouter } from "next/navigation";
+import type { Message, MessageRole } from "@/types/chat";
 import { MISSIONS } from "@/lib/missions";
-import { sendMessage } from "@/lib/chatApi";
+import { sendMessage, clearRuntimeSessionId } from "@/lib/chatApi";
+import { createClient } from "@/lib/supabase/client";
 import Sidebar from "@/components/layout/Sidebar";
 import Header from "@/components/layout/Header";
 import MessageList from "@/components/chat/MessageList";
@@ -42,9 +44,11 @@ function CloseIcon() {
 }
 
 export default function ChatPage() {
+  const router = useRouter();
   const [messages, setMessages] = useState<Message[]>([]);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [activeMissionId, setActiveMissionId] = useState(MISSIONS[0]?.id ?? "");
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -77,6 +81,65 @@ export default function ChatPage() {
       document.removeEventListener("keydown", handleEscape);
     };
   }, [isSearchOpen]);
+
+  // Load persisted conversation history whenever the active mission changes.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadHistory() {
+      setIsLoadingHistory(true);
+      requestGenerationRef.current += 1;
+      messagesRef.current = [];
+      setMessages([]);
+
+      try {
+        const supabase = createClient();
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session || cancelled) return;
+
+        const sessionKey = `stratos-session-${activeMissionId}`;
+        const sessionId =
+          (typeof window !== "undefined" &&
+            window.localStorage.getItem(sessionKey)) ??
+          null;
+
+        if (!sessionId) return;
+
+        const { data } = await supabase
+          .from("messages")
+          .select("role, content, created_at")
+          .eq("session_id", sessionId)
+          .order("created_at")
+          .limit(50);
+
+        if (cancelled || !data || data.length === 0) return;
+
+        const loaded: Message[] = data.map((m, i) => ({
+          id: `db-${i}-${m.created_at}`,
+          role: m.role as MessageRole,
+          content: m.content,
+          createdAt: new Date(m.created_at),
+        }));
+
+        messagesRef.current = loaded;
+        setMessages(loaded);
+      } catch {
+        // History load failure is non-fatal; user starts a fresh view.
+      } finally {
+        if (!cancelled) setIsLoadingHistory(false);
+      }
+    }
+
+    loadHistory();
+    return () => { cancelled = true; };
+  }, [activeMissionId]);
+
+  const handleLogout = useCallback(async () => {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/");
+    router.refresh();
+  }, [router]);
 
   const handleSend = useCallback(async (content: string) => {
     const userMessage: Message = {
@@ -132,11 +195,12 @@ export default function ChatPage() {
   }, [activeMissionId]);
 
   const handleNewChat = useCallback(() => {
+    clearRuntimeSessionId(activeMissionId);
     requestGenerationRef.current += 1;
     messagesRef.current = [];
     setMessages([]);
     setIsLoading(false);
-  }, []);
+  }, [activeMissionId]);
 
   const handleToggleSidebar = useCallback(() => {
     setIsSidebarOpen((prev) => !prev);
@@ -170,6 +234,7 @@ export default function ChatPage() {
         isOpen={isSidebarOpen}
         onNewChat={handleNewChat}
         onOpenSearch={handleOpenSearch}
+        onLogout={handleLogout}
         missions={MISSIONS}
         activeMissionId={activeMissionId}
       />
@@ -186,7 +251,7 @@ export default function ChatPage() {
         <main className={styles.chatMain}>
           <MessageList
             messages={messages}
-            isLoading={isLoading}
+            isLoading={isLoading || isLoadingHistory}
           />
           <InputBar
             onSend={handleSend}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -85,8 +85,7 @@ export default function ChatPage() {
       content,
       createdAt: new Date(),
     };
-    const priorMessages = messagesRef.current;
-    const nextMessages = [...priorMessages, userMessage];
+    const nextMessages = [...messagesRef.current, userMessage];
     const requestGeneration = ++requestGenerationRef.current;
 
     messagesRef.current = nextMessages;
@@ -94,7 +93,7 @@ export default function ChatPage() {
     setIsLoading(true);
 
     try {
-      const data = await sendMessage(content, priorMessages);
+      const data = await sendMessage(content, activeMissionId);
       if (requestGeneration !== requestGenerationRef.current) {
         return;
       }
@@ -106,6 +105,7 @@ export default function ChatPage() {
         createdAt: new Date(),
         toolCalls: data.tool_calls,
         trajectoryArtifact: data.trajectory_artifact,
+        writeResult: data.write_result,
       };
       messagesRef.current = [...messagesRef.current, assistantMessage];
       setMessages(messagesRef.current);
@@ -129,7 +129,7 @@ export default function ChatPage() {
         setIsLoading(false);
       }
     }
-  }, []);
+  }, [activeMissionId]);
 
   const handleNewChat = useCallback(() => {
     requestGenerationRef.current += 1;

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -178,6 +178,126 @@
   }
 }
 
+/* ─── Auth form ──────────────────────────────────────────────── */
+
+.form {
+  display: grid;
+  gap: 14px;
+}
+
+.formField {
+  display: grid;
+  gap: 6px;
+}
+
+.formLabel {
+  color: rgba(231, 236, 245, 0.72);
+  font-size: 0.83rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.formInput {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f7fb;
+  font: inherit;
+  font-size: 0.96rem;
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.formInput::placeholder {
+  color: rgba(231, 236, 245, 0.32);
+}
+
+.formInput:focus {
+  border-color: rgba(99, 148, 255, 0.55);
+  box-shadow: 0 0 0 3px rgba(99, 148, 255, 0.12);
+}
+
+.formError {
+  color: #ff7b7b;
+  font-size: 0.87rem;
+  line-height: 1.5;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(255, 80, 80, 0.08);
+  border: 1px solid rgba(255, 80, 80, 0.18);
+}
+
+.formSuccess {
+  color: #6ee7b7;
+  font-size: 0.87rem;
+  line-height: 1.5;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(52, 211, 153, 0.08);
+  border: 1px solid rgba(52, 211, 153, 0.18);
+}
+
+.formSubmit {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 20px;
+  margin-top: 4px;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #4a7bff 0%, #2e5ce6 100%);
+  color: #fff;
+  font: inherit;
+  font-size: 0.98rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+  box-shadow: 0 4px 16px rgba(74, 123, 255, 0.28);
+}
+
+.formSubmit:hover:not(:disabled) {
+  opacity: 0.92;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(74, 123, 255, 0.36);
+}
+
+.formSubmit:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.formSubmit:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.formToggle {
+  text-align: center;
+  color: rgba(231, 236, 245, 0.52);
+  font-size: 0.87rem;
+  margin-top: 4px;
+}
+
+.formToggleLink {
+  background: none;
+  border: none;
+  color: #7ba8ff;
+  font: inherit;
+  font-size: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: rgba(123, 168, 255, 0.4);
+  padding: 0;
+}
+
+.formToggleLink:hover {
+  color: #a0c0ff;
+}
+
 @media (max-width: 768px) {
   .page {
     padding: 20px;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,20 +1,12 @@
 "use client";
 
-import { startTransition, useEffect, useState } from "react";
+import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
 import styles from "./page.module.css";
 
-function MicrosoftLogo() {
-  return (
-    <span className={styles.microsoftLogo} aria-hidden="true">
-      <span className={styles.logoTileRed} />
-      <span className={styles.logoTileGreen} />
-      <span className={styles.logoTileBlue} />
-      <span className={styles.logoTileYellow} />
-    </span>
-  );
-}
+type AuthMode = "signin" | "signup";
 
 function LoadingSpinner() {
   return <span className={styles.spinner} aria-hidden="true" />;
@@ -22,30 +14,53 @@ function LoadingSpinner() {
 
 export default function Home() {
   const router = useRouter();
+  const [mode, setMode] = useState<AuthMode>("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isLoading) {
-      return;
-    }
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSuccessMsg(null);
+    setIsLoading(true);
 
-    const timeoutId = window.setTimeout(() => {
-      startTransition(() => {
+    const supabase = createClient();
+
+    try {
+      if (mode === "signup") {
+        const { error: signUpError } = await supabase.auth.signUp({
+          email,
+          password,
+          options: { data: { display_name: displayName || email.split("@")[0] } },
+        });
+        if (signUpError) throw signUpError;
+        setSuccessMsg("Account created — check your email to confirm, then sign in.");
+        setMode("signin");
+      } else {
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (signInError) throw signInError;
         router.push("/chat");
-      });
-    }, 1100);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [isLoading, router]);
+        router.refresh();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
 
   return (
     <main className={styles.page}>
       <div className={styles.overlay} />
       <section className={styles.loginCard} aria-label="Login panel">
         <div className={styles.authPanel}>
-          <h1 className={styles.title}>Sign in to:</h1>
           <div className={styles.brandLockup}>
             <Image
               src="/assets/STRATOS_LOGO_PNG_NO_BG/Color_text.png"
@@ -55,35 +70,111 @@ export default function Home() {
               priority
               className={styles.brandLogo}
             />
-        </div>
+          </div>
           <p className={styles.subtitle}>
-            Continue with your organization credentials to access mission chat and operations.
+            {mode === "signin"
+              ? "Sign in to access mission chat and flight operations."
+              : "Create your STRATOS account to get started."}
           </p>
         </div>
-        <button
-          className={styles.loginButton}
-          type="button"
-          disabled={isLoading}
-          aria-busy={isLoading}
-          onClick={() => setIsLoading(true)}
-        >
-          <span className={styles.loginButtonMain}>
-            <MicrosoftLogo />
-            <span className={styles.loginButtonText}>
-              {isLoading ? "Connecting to Microsoft" : "Sign in with Microsoft"}
-            </span>
-          </span>
-          <span className={styles.loginButtonMeta}>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          {mode === "signup" && (
+            <div className={styles.formField}>
+              <label className={styles.formLabel} htmlFor="displayName">
+                Display name
+              </label>
+              <input
+                id="displayName"
+                className={styles.formInput}
+                type="text"
+                autoComplete="name"
+                placeholder="Your name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+              />
+            </div>
+          )}
+
+          <div className={styles.formField}>
+            <label className={styles.formLabel} htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              className={styles.formInput}
+              type="email"
+              autoComplete="email"
+              placeholder="you@lifts-uprm.com"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+
+          <div className={styles.formField}>
+            <label className={styles.formLabel} htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              className={styles.formInput}
+              type="password"
+              autoComplete={mode === "signup" ? "new-password" : "current-password"}
+              placeholder={mode === "signup" ? "At least 6 characters" : "••••••••"}
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+
+          {error && <p className={styles.formError} role="alert">{error}</p>}
+          {successMsg && <p className={styles.formSuccess} role="status">{successMsg}</p>}
+
+          <button
+            className={styles.formSubmit}
+            type="submit"
+            disabled={isLoading}
+            aria-busy={isLoading}
+          >
             {isLoading ? (
               <>
                 <LoadingSpinner />
-                <span>Loading</span>
+                {mode === "signin" ? "Signing in…" : "Creating account…"}
+              </>
+            ) : mode === "signin" ? (
+              "Sign in"
+            ) : (
+              "Create account"
+            )}
+          </button>
+
+          <p className={styles.formToggle}>
+            {mode === "signin" ? (
+              <>
+                No account?{" "}
+                <button
+                  type="button"
+                  className={styles.formToggleLink}
+                  onClick={() => { setMode("signup"); setError(null); setSuccessMsg(null); }}
+                >
+                  Sign up
+                </button>
               </>
             ) : (
-              <span>Continue</span>
+              <>
+                Already have an account?{" "}
+                <button
+                  type="button"
+                  className={styles.formToggleLink}
+                  onClick={() => { setMode("signin"); setError(null); setSuccessMsg(null); }}
+                >
+                  Sign in
+                </button>
+              </>
             )}
-          </span>
-        </button>
+          </p>
+        </form>
       </section>
     </main>
   );

--- a/frontend/src/components/layout/Sidebar.module.css
+++ b/frontend/src/components/layout/Sidebar.module.css
@@ -247,3 +247,32 @@
   color: var(--color-text-muted);
   padding: 4px 0;
 }
+
+.sidebarFooter {
+  padding: 10px 12px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.logoutBtn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 0.83rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out);
+  text-align: left;
+}
+
+.logoutBtn:hover {
+  background: rgba(255, 100, 100, 0.08);
+  color: #ff9090;
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -38,6 +38,17 @@ function RocketIcon() {
   );
 }
 
+function LogOutIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true"
+         stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}
+
 function ChevronDownIcon({ isOpen }: { isOpen: boolean }) {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true"
@@ -53,6 +64,7 @@ interface SidebarProps {
   isOpen: boolean;
   onNewChat?: () => void;
   onOpenSearch?: () => void;
+  onLogout?: () => void;
   missions: Mission[];
   activeMissionId: string;
 }
@@ -61,6 +73,7 @@ export default function Sidebar({
   isOpen,
   onNewChat,
   onOpenSearch,
+  onLogout,
   missions,
   activeMissionId,
 }: SidebarProps) {
@@ -109,7 +122,7 @@ export default function Sidebar({
       </div>
 
       {/* Scrollable body */}
-      <div className={styles.scrollArea}>
+      <div className={styles.scrollArea} style={{ flex: 1 }}>
 
         {/* Missions */}
         <section className={styles.section}>
@@ -163,6 +176,21 @@ export default function Sidebar({
         </section>
 
       </div>
+
+      {/* Footer: logout */}
+      {onLogout && (
+        <div className={styles.sidebarFooter}>
+          <button
+            className={styles.logoutBtn}
+            type="button"
+            onClick={onLogout}
+            title="Sign out"
+          >
+            <span className={styles.quickIcon}><LogOutIcon /></span>
+            Sign out
+          </button>
+        </div>
+      )}
     </aside>
   );
 }

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -1,16 +1,25 @@
-import type { Message, TrajectoryArtifact } from "@/types/chat";
+import type { Message, TrajectoryArtifact, WriteResult } from "@/types/chat";
 
 export interface ChatApiResponse {
   response: string;
   source: string;
+  session_id: string;
+  mission_id: string;
   tool_calls?: Array<{ name: string; args: Record<string, unknown> }>;
   trajectory_artifact?: TrajectoryArtifact | null;
+  write_result?: WriteResult | null;
 }
 
-function getChatEndpoint(): string {
+const RUNTIME_SESSION_STORAGE_KEY = "stratos-runtime-session-id";
+const RUNTIME_USER_STORAGE_KEY = "stratos-runtime-user-id";
+const RUNTIME_MISSION_STORAGE_KEY = "stratos-runtime-mission-id";
+const DEFAULT_RUNTIME_USER_ID = "stratos-local-user";
+const DEFAULT_RUNTIME_MISSION_ID = "aero";
+
+function getRuntimeEndpoint(): string {
   const configuredBase = process.env.NEXT_PUBLIC_BACKEND_URL?.trim();
   if (configuredBase) {
-    return `${configuredBase.replace(/\/$/, "")}/chat`;
+    return `${configuredBase.replace(/\/$/, "")}/runtime/request`;
   }
 
   if (typeof window !== "undefined") {
@@ -18,11 +27,48 @@ function getChatEndpoint(): string {
     const isLocalDevHost = hostname === "localhost" || hostname === "127.0.0.1";
 
     if (isLocalDevHost && (protocol === "http:" || protocol === "https:")) {
-      return "http://127.0.0.1:8000/chat";
+      return "http://127.0.0.1:8000/runtime/request";
     }
   }
 
-  return "/api/chat";
+  return "/api/runtime/request";
+}
+
+function getStoredValue(key: string, fallback: string): string {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  return window.localStorage.getItem(key) || fallback;
+}
+
+function makeRuntimeSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `sess_${crypto.randomUUID()}`;
+  }
+
+  return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+}
+
+function getRuntimeSessionId(): string {
+  if (typeof window === "undefined") {
+    return makeRuntimeSessionId();
+  }
+
+  const existing = window.localStorage.getItem(RUNTIME_SESSION_STORAGE_KEY);
+  if (existing) {
+    return existing;
+  }
+
+  const sessionId = makeRuntimeSessionId();
+  window.localStorage.setItem(RUNTIME_SESSION_STORAGE_KEY, sessionId);
+  return sessionId;
+}
+
+function rememberRuntimeSessionId(sessionId: string): void {
+  if (typeof window !== "undefined" && sessionId) {
+    window.localStorage.setItem(RUNTIME_SESSION_STORAGE_KEY, sessionId);
+  }
 }
 
 /**
@@ -33,19 +79,25 @@ export async function sendMessage(
   message: string,
   history: Message[] = [],
 ): Promise<ChatApiResponse> {
+  void history;
+
   let res: Response;
 
   try {
-    const endpoint = getChatEndpoint();
+    const endpoint = getRuntimeEndpoint();
     res = await fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        user_id: getStoredValue(RUNTIME_USER_STORAGE_KEY, DEFAULT_RUNTIME_USER_ID),
+        mission_id: getStoredValue(
+          RUNTIME_MISSION_STORAGE_KEY,
+          DEFAULT_RUNTIME_MISSION_ID,
+        ),
+        session_id: getRuntimeSessionId(),
+        operation: "chat",
         message,
-        history: history.map((item) => ({
-          role: item.role,
-          content: item.content,
-        })),
+        write_intent: null,
       }),
     });
   } catch {
@@ -60,10 +112,12 @@ export async function sendMessage(
       const body = await res.json();
       if (body?.detail) detail = String(body.detail);
     } catch {
-      // ignore JSON parse failure — keep the status-code message
+      // ignore JSON parse failure - keep the status-code message
     }
     throw new Error(detail);
   }
 
-  return res.json() as Promise<ChatApiResponse>;
+  const data = (await res.json()) as ChatApiResponse;
+  rememberRuntimeSessionId(data.session_id);
+  return data;
 }

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -154,7 +154,11 @@ export async function sendMessage(
     let detail = `Server error ${res.status}`;
     try {
       const body = await res.json();
-      if (body?.detail) detail = String(body.detail);
+      if (body?.detail) {
+        detail = typeof body.detail === "string"
+          ? body.detail
+          : (body.detail?.error ?? JSON.stringify(body.detail));
+      }
     } catch {
       // ignore JSON parse failure
     }

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -61,11 +61,16 @@ function makeRuntimeSessionId(): string {
     return `sess_${crypto.randomUUID()}`;
   }
 
-  // randomUUID unavailable (very old runtime) — fall back to getRandomValues, which is CSPRNG.
-  // Never use Math.random() for a session identifier.
-  const buf = new Uint8Array(16);
-  crypto.getRandomValues(buf);
-  return `sess_${Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("")}`;
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const buf = new Uint8Array(16);
+    crypto.getRandomValues(buf);
+    return `sess_${Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  throw new Error(
+    "No cryptographically secure random source is available in this runtime. " +
+    "Session ID cannot be generated safely.",
+  );
 }
 
 function getRuntimeSessionId(): string {

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -1,3 +1,4 @@
+import { createClient } from "@/lib/supabase/client";
 import type { TrajectoryArtifact, WriteResult } from "@/types/chat";
 
 export interface ChatApiResponse {
@@ -10,10 +11,6 @@ export interface ChatApiResponse {
   write_result?: WriteResult | null;
 }
 
-const RUNTIME_SESSION_STORAGE_KEY = "stratos-runtime-session-id";
-const RUNTIME_USER_STORAGE_KEY = "stratos-runtime-user-id";
-const DEFAULT_RUNTIME_USER_ID = "stratos-local-user";
-
 function getRuntimeEndpoint(): string {
   const configuredBase = process.env.NEXT_PUBLIC_BACKEND_URL?.trim();
   if (configuredBase) {
@@ -23,7 +20,6 @@ function getRuntimeEndpoint(): string {
   if (typeof window !== "undefined") {
     const { protocol, hostname } = window.location;
     const isLocalDevHost = hostname === "localhost" || hostname === "127.0.0.1";
-
     if (isLocalDevHost && (protocol === "http:" || protocol === "https:")) {
       return "http://127.0.0.1:8000/runtime/request";
     }
@@ -48,12 +44,16 @@ function safeLocalStorageSet(key: string, value: string): void {
   }
 }
 
-function getStoredValue(key: string, fallback: string): string {
-  if (typeof window === "undefined") {
-    return fallback;
+function safeLocalStorageRemove(key: string): void {
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // ignore
   }
+}
 
-  return safeLocalStorageGet(key) || fallback;
+function sessionKey(missionId: string): string {
+  return `stratos-session-${missionId}`;
 }
 
 function makeRuntimeSessionId(): string {
@@ -73,49 +73,72 @@ function makeRuntimeSessionId(): string {
   );
 }
 
-function getRuntimeSessionId(): string {
+function getRuntimeSessionId(missionId: string): string {
   if (typeof window === "undefined") {
     return makeRuntimeSessionId();
   }
 
-  const existing = safeLocalStorageGet(RUNTIME_SESSION_STORAGE_KEY);
-  if (existing) {
-    return existing;
-  }
+  const key = sessionKey(missionId);
+  const existing = safeLocalStorageGet(key);
+  if (existing) return existing;
 
   const sessionId = makeRuntimeSessionId();
-  safeLocalStorageSet(RUNTIME_SESSION_STORAGE_KEY, sessionId);
+  safeLocalStorageSet(key, sessionId);
   return sessionId;
 }
 
-function rememberRuntimeSessionId(sessionId: string): void {
+function rememberRuntimeSessionId(missionId: string, sessionId: string): void {
   if (typeof window !== "undefined" && sessionId) {
-    safeLocalStorageSet(RUNTIME_SESSION_STORAGE_KEY, sessionId);
+    safeLocalStorageSet(sessionKey(missionId), sessionId);
   }
+}
+
+export function clearRuntimeSessionId(missionId: string): void {
+  if (typeof window !== "undefined") {
+    safeLocalStorageRemove(sessionKey(missionId));
+  }
+}
+
+async function getAuthHeaders(): Promise<{ Authorization: string; userId: string }> {
+  const supabase = createClient();
+  const { data: { session } } = await supabase.auth.getSession();
+
+  if (!session) {
+    throw new Error("Not authenticated. Please sign in.");
+  }
+
+  return {
+    Authorization: `Bearer ${session.access_token}`,
+    userId: session.user.id,
+  };
 }
 
 /**
  * Send a message to the STRATOS backend and return the response.
  * Throws an Error with a user-facing message on network or server failure.
  *
- * Client-supplied history is not forwarded — the runtime contract rejects it.
- * Server-side session continuity is managed via session_id.
+ * Session continuity is managed per-mission via session_id.
+ * Conversation history is stored server-side; the client does not send it.
  */
 export async function sendMessage(
   message: string,
   missionId: string,
 ): Promise<ChatApiResponse> {
-  let res: Response;
+  const { Authorization, userId } = await getAuthHeaders();
+  const sessionId = getRuntimeSessionId(missionId);
 
+  let res: Response;
   try {
-    const endpoint = getRuntimeEndpoint();
-    res = await fetch(endpoint, {
+    res = await fetch(getRuntimeEndpoint(), {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization,
+      },
       body: JSON.stringify({
-        user_id: getStoredValue(RUNTIME_USER_STORAGE_KEY, DEFAULT_RUNTIME_USER_ID),
+        user_id: userId,
         mission_id: missionId,
-        session_id: getRuntimeSessionId(),
+        session_id: sessionId,
         operation: "chat",
         message,
         write_intent: null,
@@ -123,7 +146,7 @@ export async function sendMessage(
     });
   } catch {
     throw new Error(
-      "Unable to reach the STRATOS backend. Check that the server is running."
+      "Unable to reach the STRATOS backend. Check that the server is running.",
     );
   }
 
@@ -133,12 +156,12 @@ export async function sendMessage(
       const body = await res.json();
       if (body?.detail) detail = String(body.detail);
     } catch {
-      // ignore JSON parse failure - keep the status-code message
+      // ignore JSON parse failure
     }
     throw new Error(detail);
   }
 
   const data = (await res.json()) as ChatApiResponse;
-  rememberRuntimeSessionId(data.session_id);
+  rememberRuntimeSessionId(missionId, data.session_id);
   return data;
 }

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -1,4 +1,4 @@
-import type { Message, TrajectoryArtifact, WriteResult } from "@/types/chat";
+import type { TrajectoryArtifact, WriteResult } from "@/types/chat";
 
 export interface ChatApiResponse {
   response: string;
@@ -12,9 +12,7 @@ export interface ChatApiResponse {
 
 const RUNTIME_SESSION_STORAGE_KEY = "stratos-runtime-session-id";
 const RUNTIME_USER_STORAGE_KEY = "stratos-runtime-user-id";
-const RUNTIME_MISSION_STORAGE_KEY = "stratos-runtime-mission-id";
 const DEFAULT_RUNTIME_USER_ID = "stratos-local-user";
-const DEFAULT_RUNTIME_MISSION_ID = "aero";
 
 function getRuntimeEndpoint(): string {
   const configuredBase = process.env.NEXT_PUBLIC_BACKEND_URL?.trim();
@@ -34,12 +32,28 @@ function getRuntimeEndpoint(): string {
   return "/api/runtime/request";
 }
 
+function safeLocalStorageGet(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeLocalStorageSet(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // storage blocked — value won't persist but the request still works
+  }
+}
+
 function getStoredValue(key: string, fallback: string): string {
   if (typeof window === "undefined") {
     return fallback;
   }
 
-  return window.localStorage.getItem(key) || fallback;
+  return safeLocalStorageGet(key) || fallback;
 }
 
 function makeRuntimeSessionId(): string {
@@ -47,7 +61,11 @@ function makeRuntimeSessionId(): string {
     return `sess_${crypto.randomUUID()}`;
   }
 
-  return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+  // randomUUID unavailable (very old runtime) — fall back to getRandomValues, which is CSPRNG.
+  // Never use Math.random() for a session identifier.
+  const buf = new Uint8Array(16);
+  crypto.getRandomValues(buf);
+  return `sess_${Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("")}`;
 }
 
 function getRuntimeSessionId(): string {
@@ -55,32 +73,33 @@ function getRuntimeSessionId(): string {
     return makeRuntimeSessionId();
   }
 
-  const existing = window.localStorage.getItem(RUNTIME_SESSION_STORAGE_KEY);
+  const existing = safeLocalStorageGet(RUNTIME_SESSION_STORAGE_KEY);
   if (existing) {
     return existing;
   }
 
   const sessionId = makeRuntimeSessionId();
-  window.localStorage.setItem(RUNTIME_SESSION_STORAGE_KEY, sessionId);
+  safeLocalStorageSet(RUNTIME_SESSION_STORAGE_KEY, sessionId);
   return sessionId;
 }
 
 function rememberRuntimeSessionId(sessionId: string): void {
   if (typeof window !== "undefined" && sessionId) {
-    window.localStorage.setItem(RUNTIME_SESSION_STORAGE_KEY, sessionId);
+    safeLocalStorageSet(RUNTIME_SESSION_STORAGE_KEY, sessionId);
   }
 }
 
 /**
  * Send a message to the STRATOS backend and return the response.
  * Throws an Error with a user-facing message on network or server failure.
+ *
+ * Client-supplied history is not forwarded — the runtime contract rejects it.
+ * Server-side session continuity is managed via session_id.
  */
 export async function sendMessage(
   message: string,
-  history: Message[] = [],
+  missionId: string,
 ): Promise<ChatApiResponse> {
-  void history;
-
   let res: Response;
 
   try {
@@ -90,10 +109,7 @@ export async function sendMessage(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         user_id: getStoredValue(RUNTIME_USER_STORAGE_KEY, DEFAULT_RUNTIME_USER_ID),
-        mission_id: getStoredValue(
-          RUNTIME_MISSION_STORAGE_KEY,
-          DEFAULT_RUNTIME_MISSION_ID,
-        ),
+        mission_id: missionId,
         session_id: getRuntimeSessionId(),
         operation: "chat",
         message,

--- a/frontend/src/lib/supabase/client.ts
+++ b/frontend/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+  );
+}

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -1,0 +1,28 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // setAll is called from a Server Component — cookies can only be
+            // set in middleware or route handlers; ignore the error here.
+          }
+        },
+      },
+    },
+  );
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,50 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  // Validate the session on the server — never rely on client-side session alone.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user && request.nextUrl.pathname.startsWith("/chat")) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  if (user && request.nextUrl.pathname === "/") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/chat";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: ["/chat/:path*", "/"],
+};

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -83,4 +83,5 @@ export interface Message {
   // Server-generated UI metadata only; never sent back as trusted /chat input.
   toolCalls?: ToolCallRecord[];
   trajectoryArtifact?: TrajectoryArtifact | null;
+  writeResult?: WriteResult | null;
 }

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -64,6 +64,17 @@ export interface TrajectoryArtifact {
   restriction_overlay?: RestrictionOverlay | null;
 }
 
+export interface WriteResult {
+  status: "validated";
+  operation:
+    | "checklist_item_set_status"
+    | "append_planning_note"
+    | "append_decision_entry"
+    | "update_status_summary";
+  target_file: string;
+  summary: string;
+}
+
 export interface Message {
   id: string;
   role: MessageRole;

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "supabase": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase/SKILL.md",
+      "computedHash": "d414d598b9428b3e851c4ce61898649906b19e55aa7415bb42a286bd9ca2ab32"
+    },
+    "supabase-postgres-best-practices": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase-postgres-best-practices/SKILL.md",
+      "computedHash": "0d2c4857a7d6fdcd3fbc46e458fa4c497f029cab89a01548b3defce203003932"
+    }
+  }
+}

--- a/supabase/migrations/20260610000000_initial_stratos_schema.sql
+++ b/supabase/migrations/20260610000000_initial_stratos_schema.sql
@@ -1,0 +1,275 @@
+-- Extensions
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA extensions;
+
+-- Helper: auto-update updated_at on any table
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- ─────────────────────────────────────────────
+-- Core tables
+-- ─────────────────────────────────────────────
+
+CREATE TABLE public.profiles (
+  id            UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name  TEXT        NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMENT ON TABLE public.profiles IS 'One row per authenticated user, auto-created on signup.';
+
+CREATE TABLE public.missions (
+  id          TEXT        PRIMARY KEY,
+  title       TEXT        NOT NULL,
+  status      TEXT        NOT NULL DEFAULT 'upcoming'
+                CHECK (status IN ('upcoming', 'in-progress', 'completed')),
+  description TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMENT ON TABLE public.missions IS 'LIFTS mission definitions (e.g. AERO, SCRAM).';
+
+CREATE TABLE public.mission_members (
+  mission_id  TEXT        NOT NULL REFERENCES public.missions(id) ON DELETE CASCADE,
+  user_id     UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  role        TEXT        NOT NULL DEFAULT 'member' CHECK (role IN ('member', 'lead')),
+  joined_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (mission_id, user_id)
+);
+COMMENT ON TABLE public.mission_members IS 'Which users belong to which missions and in what role.';
+
+CREATE TABLE public.user_sessions (
+  id              TEXT        PRIMARY KEY,
+  user_id         UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  mission_id      TEXT        NOT NULL REFERENCES public.missions(id) ON DELETE CASCADE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_active_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMENT ON TABLE public.user_sessions IS 'Hermes runtime sessions, one per user per mission conversation.';
+
+-- ─────────────────────────────────────────────
+-- Telemetry / audit tables
+-- ─────────────────────────────────────────────
+
+CREATE TABLE public.chat_usage_logs (
+  id                   BIGSERIAL   PRIMARY KEY,
+  user_id              UUID        REFERENCES public.profiles(id) ON DELETE SET NULL,
+  mission_id           TEXT        REFERENCES public.missions(id) ON DELETE SET NULL,
+  session_id           TEXT,
+  usage_source         TEXT        NOT NULL,
+  model                TEXT,
+  llm_steps            INTEGER,
+  message_chars        INTEGER,
+  response_chars       INTEGER,
+  tool_call_count      INTEGER,
+  selected_tool_groups TEXT[],
+  elapsed_seconds      NUMERIC(10,3),
+  recorded_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMENT ON TABLE public.chat_usage_logs IS 'Per-request LLM usage telemetry written by the backend service role.';
+
+CREATE TABLE public.mission_write_events (
+  id           BIGSERIAL   PRIMARY KEY,
+  user_id      UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  mission_id   TEXT        NOT NULL REFERENCES public.missions(id) ON DELETE CASCADE,
+  session_id   TEXT,
+  operation    TEXT        NOT NULL,
+  target_file  TEXT        NOT NULL,
+  summary      TEXT,
+  applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMENT ON TABLE public.mission_write_events IS 'Audit trail for constrained shared mission doc writes.';
+
+-- ─────────────────────────────────────────────
+-- Vector / RAG table (future use)
+-- ─────────────────────────────────────────────
+
+CREATE TABLE public.mission_doc_embeddings (
+  id           BIGSERIAL   PRIMARY KEY,
+  mission_id   TEXT        NOT NULL REFERENCES public.missions(id) ON DELETE CASCADE,
+  file_path    TEXT        NOT NULL,
+  chunk_index  INTEGER     NOT NULL DEFAULT 0,
+  content      TEXT        NOT NULL,
+  embedding    extensions.vector(1536),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (mission_id, file_path, chunk_index)
+);
+COMMENT ON TABLE public.mission_doc_embeddings IS 'Chunked mission doc embeddings for RAG retrieval (1536-dim OpenAI text-embedding-3-small).';
+
+-- ─────────────────────────────────────────────
+-- Indexes
+-- ─────────────────────────────────────────────
+
+CREATE INDEX idx_mission_members_user         ON public.mission_members (user_id);
+CREATE INDEX idx_user_sessions_user           ON public.user_sessions (user_id);
+CREATE INDEX idx_user_sessions_mission        ON public.user_sessions (mission_id);
+CREATE INDEX idx_chat_usage_logs_user         ON public.chat_usage_logs (user_id);
+CREATE INDEX idx_chat_usage_logs_mission      ON public.chat_usage_logs (mission_id);
+CREATE INDEX idx_chat_usage_logs_recorded_at  ON public.chat_usage_logs (recorded_at DESC);
+CREATE INDEX idx_mission_write_events_mission ON public.mission_write_events (mission_id);
+CREATE INDEX idx_mission_write_events_user    ON public.mission_write_events (user_id);
+CREATE INDEX idx_mission_doc_embeddings_file  ON public.mission_doc_embeddings (mission_id, file_path);
+
+-- ─────────────────────────────────────────────
+-- updated_at triggers
+-- ─────────────────────────────────────────────
+
+CREATE TRIGGER set_profiles_updated_at
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER set_missions_updated_at
+  BEFORE UPDATE ON public.missions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER set_mission_doc_embeddings_updated_at
+  BEFORE UPDATE ON public.mission_doc_embeddings
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ─────────────────────────────────────────────
+-- Auth trigger: auto-create profile on signup
+-- ─────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, display_name)
+  VALUES (
+    NEW.id,
+    COALESCE(
+      NEW.raw_user_meta_data->>'display_name',
+      split_part(NEW.email, '@', 1)
+    )
+  );
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ─────────────────────────────────────────────
+-- Row Level Security
+-- ─────────────────────────────────────────────
+
+ALTER TABLE public.profiles               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.missions               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_members        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_sessions          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_usage_logs        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_write_events   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_doc_embeddings ENABLE ROW LEVEL SECURITY;
+
+-- profiles
+CREATE POLICY "profiles_select_own" ON public.profiles
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = id);
+
+CREATE POLICY "profiles_update_own" ON public.profiles
+  FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = id)
+  WITH CHECK ((SELECT auth.uid()) = id);
+
+-- missions: visible to members only
+CREATE POLICY "missions_select_member" ON public.missions
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.mission_members mm
+      WHERE mm.mission_id = missions.id
+        AND mm.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- mission_members
+CREATE POLICY "mission_members_select_own" ON public.mission_members
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+-- user_sessions
+CREATE POLICY "user_sessions_select_own" ON public.user_sessions
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "user_sessions_insert_own" ON public.user_sessions
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "user_sessions_update_own" ON public.user_sessions
+  FOR UPDATE TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+-- chat_usage_logs: service role writes, users read their own
+CREATE POLICY "chat_usage_logs_select_own" ON public.chat_usage_logs
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+-- mission_write_events: mission members read
+CREATE POLICY "mission_write_events_select_member" ON public.mission_write_events
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.mission_members mm
+      WHERE mm.mission_id = mission_write_events.mission_id
+        AND mm.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- mission_doc_embeddings: mission members read
+CREATE POLICY "mission_doc_embeddings_select_member" ON public.mission_doc_embeddings
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.mission_members mm
+      WHERE mm.mission_id = mission_doc_embeddings.mission_id
+        AND mm.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- ─────────────────────────────────────────────
+-- Storage: private mission workspace bucket
+-- ─────────────────────────────────────────────
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'mission-workspace',
+  'mission-workspace',
+  false,
+  52428800,
+  ARRAY['text/markdown', 'text/plain', 'application/json']
+);
+
+-- Authenticated mission members can read their mission files
+-- Path convention inside the bucket: missions/{mission_id}/...
+CREATE POLICY "mission_workspace_select_member" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'mission-workspace'
+    AND EXISTS (
+      SELECT 1 FROM public.mission_members mm
+      WHERE mm.mission_id = split_part(name, '/', 2)
+        AND mm.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- ─────────────────────────────────────────────
+-- Seed data: existing missions
+-- ─────────────────────────────────────────────
+
+INSERT INTO public.missions (id, title, status) VALUES
+  ('m1', 'ASCENT Sub-Scale', 'in-progress'),
+  ('m2', 'ASCENT',           'upcoming'),
+  ('m3', 'Nexo',             'completed');

--- a/supabase/migrations/20260610000001_add_messages.sql
+++ b/supabase/migrations/20260610000001_add_messages.sql
@@ -1,0 +1,23 @@
+CREATE TABLE public.messages (
+  id         BIGSERIAL   PRIMARY KEY,
+  session_id TEXT        NOT NULL,
+  user_id    UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  mission_id TEXT        NOT NULL REFERENCES public.missions(id) ON DELETE CASCADE,
+  role       TEXT        NOT NULL CHECK (role IN ('user', 'assistant')),
+  content    TEXT        NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMENT ON TABLE public.messages IS 'Per-session conversation history, written by the backend service role.';
+
+CREATE INDEX idx_messages_session ON public.messages (session_id, created_at);
+CREATE INDEX idx_messages_user    ON public.messages (user_id);
+
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+
+-- Users read their own messages; backend (service role) handles all writes
+CREATE POLICY "messages_select_own" ON public.messages
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+-- Allow authenticated users to query via Data API
+GRANT SELECT ON public.messages TO authenticated;


### PR DESCRIPTION
## Summary
- Adds `POST /runtime/request` as the v1 mission-aware runtime contract for issue #118.
- Validates `user_id`, `mission_id`, `session_id`, `operation`, and structured write intents.
- Preserves legacy `/chat` while routing runtime chat through the existing tool loop without client-supplied history.
- Updates the frontend send path to post runtime payloads and documents the new API contract.

Closes #118

## Validation
- `backend/.venv/bin/python -m pytest` -> 54 passed
- `backend/.venv/bin/ruff check .` -> passed
- `cd frontend && npm run lint` -> passed
- `cd frontend && npm run build` -> passed